### PR TITLE
Add LIFO example to documentation

### DIFF
--- a/docs/book/usage.md
+++ b/docs/book/usage.md
@@ -105,9 +105,9 @@ before the "guest" role, the example code would print "allowed".
 
 ### LIFO order for Role parents
 
-When specifying multiple parents for a role the last parent listed is the first
-one searched for rules applicable to an authorization query. This Last-In-First-Out (LIFO) strategy is represented with this example.
-Here the `first` role inherits from `second`, `third`, and `last` and is the most permissioned role:
+When specifying multiple parents for a role the last parent listed is the first one searched for rules applicable to an authorization query.
+This Last-In-First-Out (LIFO) strategy is represented with this example.
+Here the `first` role inherits from `second`, `third`, and `last`, and is the most permissioned role:
 
 ```php
 use Zend\Permissions\Acl\Acl;
@@ -131,13 +131,16 @@ $acl->allow('third', 'someResource');
 echo $acl->isAllowed('first', 'someResource') ? 'allowed' : 'denied';
 ```
 
-Less-permissioned roles will be first in the parents array. For instance, where a`guest`
-role is unauthenticated, a `user` role is authenticated, and an `admin` role has the highest
-permissions. As soon as any ACL query returns false evaluation of `isAllowed` is terminated and false is returned.  For this reason your least permissioned roles come first in the parents array. Adding the `admin` role is as follows:
+Less-permissioned roles will be first in the parents array.
+For instance, where a`guest` role is unauthenticated, a `user` role is authenticated, and an `admin` role has the highest permissions.
+As soon as any ACL query returns false evaluation of `isAllowed` is terminated and false is returned.
+For this reason your least permissioned roles come first in the parents array.
+Adding the `admin` role is as follows:
 
 ```php
 $acl->addRole(new Role('admin'), ['guest', 'user']);
 ```
+
 ## Creating the Access Control List
 
 An Access Control List (ACL) can represent any set of physical or virtual objects that you wish.

--- a/docs/book/usage.md
+++ b/docs/book/usage.md
@@ -103,10 +103,24 @@ having inherited conflicting rules from different parent roles.
 rule that is directly applicable to the query. In this case, since the "member" role is examined
 before the "guest" role, the example code would print "allowed".
 
-> ### LIFO Order for Role Queries
->
-> When specifying multiple parents for a role, keep in mind that the last parent listed is the first
-> one searched for rules applicable to an authorization query.
+### LIFO/FILO order for Role parents
+
+When specifying multiple parents for a role the last parent listed is the first
+one searched for rules applicable to an authorization query.  This Last-In-First-Out
+(aka First-In-Last-Out) strategy is represented with this example.
+Here the `first` role is the highest order:
+
+```
+$acl->addRole(new Role('first'), ['last', 'third', 'second']);
+```
+
+Less-permissioned roles will be first in the parents array.  For instance, where a`guest`
+role is unauthenticated, a `user` role is authenticated, and an `admin` role has the highest
+permissions, adding the `admin` role is as follows:
+
+```
+$acl->addRole(new Role('admin'), ['guest', 'user']);
+```
 
 ## Creating the Access Control List
 

--- a/docs/book/usage.md
+++ b/docs/book/usage.md
@@ -103,25 +103,41 @@ having inherited conflicting rules from different parent roles.
 rule that is directly applicable to the query. In this case, since the "member" role is examined
 before the "guest" role, the example code would print "allowed".
 
-### LIFO/FILO order for Role parents
+### LIFO order for Role parents
 
 When specifying multiple parents for a role the last parent listed is the first
-one searched for rules applicable to an authorization query.  This Last-In-First-Out
-(aka First-In-Last-Out) strategy is represented with this example.
-Here the `first` role is the highest order:
+one searched for rules applicable to an authorization query. This Last-In-First-Out (LIFO) strategy is represented with this example.
+Here the `first` role inherits from `second`, `third`, and `last` and is the most permissioned role:
 
-```
+```php
+use Zend\Permissions\Acl\Acl;
+use Zend\Permissions\Acl\Role\GenericRole as Role;
+use Zend\Permissions\Acl\Resource\GenericResource as Resource;
+
+$acl = new Acl();
+
+$acl->addRole(new Role('last'))
+    ->addRole(new Role('third'))
+    ->addRole(new Role('second'));
+
 $acl->addRole(new Role('first'), ['last', 'third', 'second']);
+
+$acl->addResource(new Resource('someResource'));
+
+$acl->deny('last', 'someResource');
+$acl->allow('third', 'someResource');
+
+// allowed
+echo $acl->isAllowed('first', 'someResource') ? 'allowed' : 'denied';
 ```
 
-Less-permissioned roles will be first in the parents array.  For instance, where a`guest`
+Less-permissioned roles will be first in the parents array. For instance, where a`guest`
 role is unauthenticated, a `user` role is authenticated, and an `admin` role has the highest
-permissions, adding the `admin` role is as follows:
+permissions. As soon as any ACL query returns false evaluation of `isAllowed` is terminated and false is returned.  For this reason your least permissioned roles come first in the parents array. Adding the `admin` role is as follows:
 
-```
+```php
 $acl->addRole(new Role('admin'), ['guest', 'user']);
 ```
-
 ## Creating the Access Control List
 
 An Access Control List (ACL) can represent any set of physical or virtual objects that you wish.


### PR DESCRIPTION
This patch ports zendframework/zend-permissions-acl#34 to this package, bringing in an example of how LIFO order of ancestors is used for determining access.

Fixes #1