### PR TITLE
Use provided assertion implementation to determine rule type

### DIFF
--- a/test/AclTest.php
+++ b/test/AclTest.php
@@ -1462,4 +1462,22 @@ class AclTest extends TestCase
         $this->acl->allow('admin');
         $this->assertTrue($this->acl->isAllowed('admin'));
     }
+
+    /**
+     * @see https://github.com/laminas/laminas-permissions-acl/issues/2
+     */
+    public function testWhenAssertionReturnsFalseTheInversionOfItsTypeShouldBeUsed()
+    {
+        $assertAllow = new TestAsset\ChildBooleanAssertion(true);
+        $assertDeny  = new TestAsset\ChildBooleanAssertion(false);
+
+        $this->acl->addRole('staff');
+        $this->acl->addResource('base');
+        $this->acl->allow('staff', 'base', 'update', $assertAllow);
+
+        $this->acl->addResource('user', 'base');
+        $this->acl->allow('staff', 'user', 'update', $assertDeny);
+
+        $this->assertFalse($this->acl->isAllowed('staff', 'user', 'update'));
+    }
 }

--- a/test/TestAsset/ChildBooleanAssertion.php
+++ b/test/TestAsset/ChildBooleanAssertion.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-permissions-acl/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-permissions-acl/blob/master/LICENSE.md New BSD License
+ */
+
+namespace LaminasTest\Permissions\Acl\TestAsset;
+
+use Laminas\Permissions\Acl\Acl;
+use Laminas\Permissions\Acl\Assertion\AssertionInterface;
+use Laminas\Permissions\Acl\Resource\ResourceInterface;
+use Laminas\Permissions\Acl\Role\RoleInterface;
+
+/**
+ * @see https://github.com/laminas/laminas-permissions-acl/issues/2
+ */
+class ChildBooleanAssertion implements AssertionInterface
+{
+    /** @var bool */
+    private $value;
+
+    public function __construct($value)
+    {
+        $this->value = (bool) $value;
+    }
+
+    public function assert(Acl $acl, RoleInterface $role = null, ResourceInterface $resource = null, $privilege = null)
+    {
+        return $this->value;
+    }
+}


### PR DESCRIPTION
Previously, when an `AssertionInterface` was provided with a rule, and it returned false, the return value was ignored, and the rule type specified when creating the rule (one of `Acl::TYPE_ALLOW` or `Acl::TYPE_DENY`) was used.
This would lead to unexpected results, particularly when the rule type specified was `Acl::TYPE_ALLOW`, but the assertion failed; in these cases, the assertion always passed.

This patch updates the logic in `Acl::getRuleType()` to use the assertion return value in order to determine what rule type to return:

- When `true`, return the rule type as specified.
- When `false`, return the inverse of the rule type specified (e.g., if `Acl::TYPE_ALLOW` was specified, return `Acl::TYPE_DENY`, and vice versa).

All previous tests continue to pass, and the use case as presented in #2 now successfully passes as well.

Fixes #2