### PR TITLE
Feature/#11 php8.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,42 +6,21 @@ cache:
 
 env:
   global:
-    - COMPOSER_ARGS="--no-interaction"
+    - COMPOSER_ARGS="--no-interaction --ignore-platform-reqs"
     - COVERAGE_DEPS="php-coveralls/php-coveralls"
 
 matrix:
   fast_finish: true
   include:
-    - php: 5.6
-      env:
-        - DEPS=lowest
-    - php: 5.6
-      env:
-        - DEPS=latest
-    - php: 7
-      env:
-        - DEPS=lowest
-    - php: 7
-      env:
-        - DEPS=latest
-    - php: 7.1
-      env:
-        - DEPS=lowest
-    - php: 7.1
+    - php: 7.3
       env:
         - DEPS=latest
         - CS_CHECK=true
         - TEST_COVERAGE=true
-    - php: 7.2
-      env:
-        - DEPS=lowest
-    - php: 7.2
-      env:
-        - DEPS=latest
     - php: 7.3
       env:
         - DEPS=lowest
-    - php: 7.3
+    - php: 8.0
       env:
         - DEPS=latest
 

--- a/composer.json
+++ b/composer.json
@@ -21,13 +21,13 @@
     "extra": {
     },
     "require": {
-        "php": "^5.6 || ^7.0",
+        "php": "^7.3 || ^8.0",
         "laminas/laminas-zendframework-bridge": "^1.0"
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~1.0.0",
         "laminas/laminas-servicemanager": "^2.7.5 || ^3.0.3",
-        "phpunit/phpunit": "^5.7.27 || ^6.5.8 || ^7.1.5"
+        "phpunit/phpunit": "^9.5"
     },
     "suggest": {
         "laminas/laminas-servicemanager": "To support Laminas\\Permissions\\Acl\\Assertion\\AssertionManager plugin manager usage"

--- a/test/AclTest.php
+++ b/test/AclTest.php
@@ -30,7 +30,7 @@ class AclTest extends TestCase
      *
      * @return void
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->acl = new Acl\Acl();
     }
@@ -140,7 +140,7 @@ class AclTest extends TestCase
                 'Expected Laminas\Permissions\Acl\Role\Exception not thrown upon specifying a non-existent child Role'
             );
         } catch (Acl\Exception\InvalidArgumentException $e) {
-            $this->assertContains('not found', $e->getMessage());
+            $this->assertStringContainsString('not found', $e->getMessage());
         }
         try {
             $this->acl->inheritsRole($roleGuest, 'nonexistent');
@@ -148,7 +148,7 @@ class AclTest extends TestCase
                 'Expected Laminas\Permissions\Acl\Role\Exception not thrown upon specifying a non-existent child Role'
             );
         } catch (Acl\Exception\InvalidArgumentException $e) {
-            $this->assertContains('not found', $e->getMessage());
+            $this->assertStringContainsString('not found', $e->getMessage());
         }
     }
 
@@ -405,7 +405,7 @@ class AclTest extends TestCase
                 . ' thrown upon specifying a non-existent child Resource'
             );
         } catch (Acl\Exception\ExceptionInterface $e) {
-            $this->assertContains('not found', $e->getMessage());
+            $this->assertStringContainsString('not found', $e->getMessage());
         }
         try {
             $this->acl->inheritsResource($resourceArea, 'nonexistent');
@@ -414,7 +414,7 @@ class AclTest extends TestCase
                 . 'upon specifying a non-existent parent Resource'
             );
         } catch (Acl\Exception\ExceptionInterface $e) {
-            $this->assertContains('not found', $e->getMessage());
+            $this->assertStringContainsString('not found', $e->getMessage());
         }
     }
 
@@ -490,7 +490,7 @@ class AclTest extends TestCase
                 'Expected Laminas\Permissions\Acl\Role\Exception\ExceptionInterface not thrown upon non-existent Role'
             );
         } catch (Acl\Exception\InvalidArgumentException $e) {
-            $this->assertContains('not found', $e->getMessage());
+            $this->assertStringContainsString('not found', $e->getMessage());
         }
         try {
             $this->acl->isAllowed(null, 'nonexistent');
@@ -498,7 +498,7 @@ class AclTest extends TestCase
                 'Expected Laminas\Permissions\Acl\Exception\ExceptionInterface not thrown upon non-existent Resource'
             );
         } catch (Acl\Exception\InvalidArgumentException $e) {
-            $this->assertContains('not found', $e->getMessage());
+            $this->assertStringContainsString('not found', $e->getMessage());
         }
     }
 
@@ -880,7 +880,7 @@ class AclTest extends TestCase
                 'Expected Laminas\Permissions\Acl\Role\Exception not thrown upon isAllowed() on non-existent Role'
             );
         } catch (Acl\Exception\InvalidArgumentException $e) {
-            $this->assertContains('not found', $e->getMessage());
+            $this->assertStringContainsString('not found', $e->getMessage());
         }
         $this->acl->addRole(new Role\GenericRole('guest'));
         $this->assertFalse($this->acl->isAllowed('guest'));
@@ -905,7 +905,7 @@ class AclTest extends TestCase
                 'Expected Laminas\Permissions\Acl\Role\Exception not thrown upon isAllowed() on non-existent Role'
             );
         } catch (Acl\Exception\InvalidArgumentException $e) {
-            $this->assertContains('not found', $e->getMessage());
+            $this->assertStringContainsString('not found', $e->getMessage());
         }
         $this->acl->addRole(new Role\GenericRole('guest'));
         $this->assertFalse($this->acl->isAllowed('guest'));
@@ -929,7 +929,7 @@ class AclTest extends TestCase
                 'Expected Laminas\Permissions\Acl\Exception not thrown upon isAllowed() on non-existent Resource'
             );
         } catch (Acl\Exception\ExceptionInterface $e) {
-            $this->assertContains('not found', $e->getMessage());
+            $this->assertStringContainsString('not found', $e->getMessage());
         }
         $this->acl->addResource(new Resource\GenericResource('area'));
         $this->assertFalse($this->acl->isAllowed(null, 'area'));
@@ -954,7 +954,7 @@ class AclTest extends TestCase
                 . 'isAllowed() on non-existent Resource'
             );
         } catch (Acl\Exception\ExceptionInterface $e) {
-            $this->assertContains('not found', $e->getMessage());
+            $this->assertStringContainsString('not found', $e->getMessage());
         }
         $this->acl->addResource(new Resource\GenericResource('area'));
         $this->assertFalse($this->acl->isAllowed(null, 'area'));

--- a/test/Assertion/AssertionAggregateTest.php
+++ b/test/Assertion/AssertionAggregateTest.php
@@ -9,7 +9,7 @@ namespace LaminasTest\Permissions\Acl\Assertion;
 
 use InvalidArgumentException as PHPInvalidArgumentException;
 use Laminas\Permissions\Acl\Acl;
-use Laminas\Permissions\Acl\Assertion\AssertionAggregate;
+use LaminasTest\Permissions\Acl\Assertion\TestSubclasses\AssertionAggregate;
 use Laminas\Permissions\Acl\Assertion\Exception\InvalidAssertionException;
 use Laminas\Permissions\Acl\Exception\InvalidArgumentException;
 use Laminas\Permissions\Acl\Exception\RuntimeException;
@@ -21,7 +21,7 @@ class AssertionAggregateTest extends TestCase
 {
     protected $assertionAggregate;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->assertionAggregate = new AssertionAggregate();
     }
@@ -31,15 +31,13 @@ class AssertionAggregateTest extends TestCase
         $assertion = $this->getMockForAbstractClass('\Laminas\Permissions\Acl\Assertion\AssertionInterface');
         $this->assertionAggregate->addAssertion($assertion);
 
-        $this->assertAttributeEquals([
-            $assertion
-        ], 'assertions', $this->assertionAggregate);
+        $this->assertEquals([$assertion], $this->assertionAggregate->peakAssertions());
 
         $aggregate = $this->assertionAggregate->addAssertion('other.assertion');
-        $this->assertAttributeEquals([
+        $this->assertEquals([
             $assertion,
             'other.assertion'
-        ], 'assertions', $this->assertionAggregate);
+        ], $this->assertionAggregate->peakAssertions());
 
         // test fluent interface
         $this->assertSame($this->assertionAggregate, $aggregate);
@@ -54,7 +52,7 @@ class AssertionAggregateTest extends TestCase
 
         $aggregate = $this->assertionAggregate->addAssertions($assertions);
 
-        $this->assertAttributeEquals($assertions, 'assertions', $this->assertionAggregate);
+        $this->assertEquals($assertions, $this->assertionAggregate->peakAssertions());
 
         // test fluent interface
         $this->assertSame($this->assertionAggregate, $aggregate);
@@ -65,11 +63,11 @@ class AssertionAggregateTest extends TestCase
      */
     public function testClearAssertions(AssertionAggregate $assertionAggregate)
     {
-        $this->assertAttributeCount(2, 'assertions', $assertionAggregate);
+        $this->assertCount(2, $assertionAggregate->peakAssertions());
 
         $aggregate = $assertionAggregate->clearAssertions();
 
-        $this->assertAttributeEmpty('assertions', $assertionAggregate);
+        $this->assertEmpty($assertionAggregate->peakAssertions());
 
         // test fluent interface
         $this->assertSame($assertionAggregate, $aggregate);
@@ -77,7 +75,7 @@ class AssertionAggregateTest extends TestCase
 
     public function testDefaultModeValue()
     {
-        $this->assertAttributeEquals(AssertionAggregate::MODE_ALL, 'mode', $this->assertionAggregate);
+        $this->assertEquals(AssertionAggregate::MODE_ALL, $this->assertionAggregate->peakMode());
     }
 
     /**
@@ -90,7 +88,7 @@ class AssertionAggregateTest extends TestCase
             $this->assertionAggregate->setMode($mode);
         } else {
             $this->assertionAggregate->setMode($mode);
-            $this->assertAttributeEquals($mode, 'mode', $this->assertionAggregate);
+            $this->assertEquals($mode, $this->assertionAggregate->peakMode());
         }
     }
 
@@ -117,7 +115,6 @@ class AssertionAggregateTest extends TestCase
                         ->getMock();
 
         $aggregate = $this->assertionAggregate->setAssertionManager($manager);
-        $this->assertAttributeEquals($manager, 'assertionManager', $this->assertionAggregate);
         $this->assertEquals($manager, $this->assertionAggregate->getAssertionManager());
         $this->assertSame($this->assertionAggregate, $aggregate);
     }

--- a/test/Assertion/AssertionManagerTest.php
+++ b/test/Assertion/AssertionManagerTest.php
@@ -17,7 +17,7 @@ class AssertionManagerTest extends TestCase
 {
     protected $manager;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->manager = new AssertionManager(new ServiceManager);
     }

--- a/test/Assertion/CallbackAssertionTest.php
+++ b/test/Assertion/CallbackAssertionTest.php
@@ -9,6 +9,7 @@ namespace LaminasTest\Permissions\Acl\Assertion;
 
 use Laminas\Permissions\Acl;
 use Laminas\Permissions\Acl\Exception\InvalidArgumentException;
+use LaminasTest\Permissions\Acl\Assertion\TestSubclasses\CallbackAssertion;
 use PHPUnit\Framework\TestCase;
 
 class CallbackAssertionTest extends TestCase
@@ -22,7 +23,7 @@ class CallbackAssertionTest extends TestCase
             InvalidArgumentException::class,
             'Invalid callback provided; not callable'
         );
-        new Acl\Assertion\CallbackAssertion('I am not callable!');
+        new CallbackAssertion('I am not callable!');
     }
 
     /**
@@ -32,8 +33,8 @@ class CallbackAssertionTest extends TestCase
     {
         $callback   = function () {
         };
-        $assert     = new Acl\Assertion\CallbackAssertion($callback);
-        $this->assertAttributeSame($callback, 'callback', $assert);
+        $assert     = new CallbackAssertion($callback);
+        $this->assertSame($callback, $assert->peakCallback());
     }
 
     /**
@@ -43,7 +44,7 @@ class CallbackAssertionTest extends TestCase
     {
         $acl       = new Acl\Acl();
         $that      = $this;
-        $assert    = new Acl\Assertion\CallbackAssertion(
+        $assert    = new CallbackAssertion(
             function ($aclArg, $roleArg, $resourceArg, $privilegeArg) use ($that, $acl) {
                 $that->assertSame($acl, $aclArg);
                 $that->assertInstanceOf('Laminas\Permissions\Acl\Role\RoleInterface', $roleArg);
@@ -74,9 +75,9 @@ class CallbackAssertionTest extends TestCase
             };
         };
         $acl->addRole($roleGuest);
-        $acl->allow($roleGuest, null, 'somePrivilege', new Acl\Assertion\CallbackAssertion($assertMock(true)));
+        $acl->allow($roleGuest, null, 'somePrivilege', new CallbackAssertion($assertMock(true)));
         $this->assertTrue($acl->isAllowed($roleGuest, null, 'somePrivilege'));
-        $acl->allow($roleGuest, null, 'somePrivilege', new Acl\Assertion\CallbackAssertion($assertMock(false)));
+        $acl->allow($roleGuest, null, 'somePrivilege', new CallbackAssertion($assertMock(false)));
         $this->assertFalse($acl->isAllowed($roleGuest, null, 'somePrivilege'));
     }
 }

--- a/test/Assertion/ExpressionAssertionTest.php
+++ b/test/Assertion/ExpressionAssertionTest.php
@@ -379,12 +379,12 @@ class ExpressionAssertionTest extends TestCase
 
         $serializedAssertion = serialize($assertion);
 
-        $this->assertContains('left', $serializedAssertion);
-        $this->assertContains('foo', $serializedAssertion);
-        $this->assertContains('operator', $serializedAssertion);
-        $this->assertContains('=', $serializedAssertion);
-        $this->assertContains('right', $serializedAssertion);
-        $this->assertContains('bar', $serializedAssertion);
+        $this->assertStringContainsString('left', $serializedAssertion);
+        $this->assertStringContainsString('foo', $serializedAssertion);
+        $this->assertStringContainsString('operator', $serializedAssertion);
+        $this->assertStringContainsString('=', $serializedAssertion);
+        $this->assertStringContainsString('right', $serializedAssertion);
+        $this->assertStringContainsString('bar', $serializedAssertion);
     }
 
     public function testSerializationShouldNotSerializeAssertContext()
@@ -397,6 +397,6 @@ class ExpressionAssertionTest extends TestCase
 
         $serializedAssertion = serialize($assertion);
 
-        $this->assertNotContains('assertContext', $serializedAssertion);
+        $this->assertStringNotContainsString('assertContext', $serializedAssertion);
     }
 }

--- a/test/Assertion/TestSubclasses/AssertionAggregate.php
+++ b/test/Assertion/TestSubclasses/AssertionAggregate.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-permissions-acl/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-permissions-acl/blob/master/LICENSE.md New BSD License
+ */
+namespace LaminasTest\Permissions\Acl\Assertion\TestSubclasses;
+
+final class AssertionAggregate extends \Laminas\Permissions\Acl\Assertion\AssertionAggregate
+{
+    /**
+     *
+     * @return array
+     */
+    public function peakAssertions(): array
+    {
+        return $this->assertions;
+    }
+
+    /**
+     *
+     * @return string
+     */
+    public function peakMode(): string
+    {
+        return $this->mode;
+    }
+}

--- a/test/Assertion/TestSubclasses/CallbackAssertion.php
+++ b/test/Assertion/TestSubclasses/CallbackAssertion.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-permissions-acl/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-permissions-acl/blob/master/LICENSE.md New BSD License
+ */
+namespace LaminasTest\Permissions\Acl\Assertion\TestSubclasses;
+
+final class CallbackAssertion extends \Laminas\Permissions\Acl\Assertion\CallbackAssertion
+{
+    /**
+     *
+     * @return string
+     */
+    public function peakCallback(): callable
+    {
+        return $this->callback;
+    }
+}


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | yes

### Description

Fixes issue #11 - PHP 8.0 support.

* Adds php 8.0 as a supported php version in composer.json.
* Updates phpunit to v9.5 in composer.json.
* Fixes changes to phpunit function definitions in subclasses.
* Replaces deprecated assertAttribute* methods by using subclasses that provide public getters for protected attributes.
* Replaces assertContains() method uses with assertStringContainsString() calls as per phpunit 9 changes.
* Attempted update of travis config.

I have made a best guess with travis as I neither use it or can test it.

Also note that the version of php_codesniffer specified in the laminas-coding-standard package won't run on php 8.0. I tested coding standard compliance using php 7.3.

Please let me know if I've missed anything! :)