### PR TITLE
Add PHP 8.1 support

### DIFF
--- a/.laminas-ci.json
+++ b/.laminas-ci.json
@@ -1,4 +1,5 @@
 {
-    "exclude": [
-    ]
+    "ignore_php_platform_requirements": {
+        "8.1": true
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -28,7 +28,7 @@
     "require-dev": {
         "laminas/laminas-coding-standard": "~1.0.0",
         "laminas/laminas-servicemanager": "^3.0.3",
-        "phpunit/phpunit": "^9.5"
+        "phpunit/phpunit": "^9.5.5"
     },
     "suggest": {
         "laminas/laminas-servicemanager": "To support Laminas\\Permissions\\Acl\\Assertion\\AssertionManager plugin manager usage"

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "laminas/laminas-servicemanager": "<3.0"
     },
     "require": {
-        "php": "^7.3 || ~8.0.0",
+        "php": "~7.4.0 || ~8.0.0",
         "laminas/laminas-zendframework-bridge": "^1.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "require": {
         "php": "~7.4.0 || ~8.0.0",
-        "laminas/laminas-zendframework-bridge": "^1.0"
+        "laminas/laminas-zendframework-bridge": "^1.4.0"
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~1.0.0",

--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~1.0.0",
-        "laminas/laminas-servicemanager": "^3.0.3",
+        "laminas/laminas-servicemanager": "^3.8.0",
         "phpunit/phpunit": "^9.5.5"
     },
     "suggest": {

--- a/composer.json
+++ b/composer.json
@@ -26,7 +26,7 @@
         "laminas/laminas-zendframework-bridge": "^1.4.0"
     },
     "require-dev": {
-        "laminas/laminas-coding-standard": "~1.0.0",
+        "laminas/laminas-coding-standard": "^2.0.0",
         "laminas/laminas-servicemanager": "^3.8.0",
         "phpunit/phpunit": "^9.5.5"
     },

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "laminas/laminas-servicemanager": "<3.0"
     },
     "require": {
-        "php": "~7.4.0 || ~8.0.0",
+        "php": "~7.4.0 || ~8.0.0 || ~8.1.0",
         "laminas/laminas-zendframework-bridge": "^1.4.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "0ae0dc9fad728595fa397c5c1c7e9cb7",
+    "content-hash": "64ae8286a40496ca494c4ea4daaca37a",
     "packages": [
         {
             "name": "laminas/laminas-zendframework-bridge",
@@ -219,46 +219,45 @@
         },
         {
             "name": "laminas/laminas-servicemanager",
-            "version": "3.6.4",
+            "version": "3.10.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-servicemanager.git",
-                "reference": "b1445e1a7077c21b0fad0974a1b7a11b9dbe0828"
+                "reference": "e52b985909e0940bf22d34f322eb3f48bbef6bd1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/b1445e1a7077c21b0fad0974a1b7a11b9dbe0828",
-                "reference": "b1445e1a7077c21b0fad0974a1b7a11b9dbe0828",
+                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/e52b985909e0940bf22d34f322eb3f48bbef6bd1",
+                "reference": "e52b985909e0940bf22d34f322eb3f48bbef6bd1",
                 "shasum": ""
             },
             "require": {
                 "container-interop/container-interop": "^1.2",
                 "laminas/laminas-stdlib": "^3.2.1",
-                "laminas/laminas-zendframework-bridge": "^1.0",
-                "php": "^7.3 || ~8.0.0",
+                "php": "~7.4.0 || ~8.0.0 || ~8.1.0",
                 "psr/container": "^1.0"
             },
             "conflict": {
                 "laminas/laminas-code": "<3.3.1",
-                "zendframework/zend-code": "<3.3.1"
+                "zendframework/zend-code": "<3.3.1",
+                "zendframework/zend-servicemanager": "*"
             },
             "provide": {
                 "container-interop/container-interop-implementation": "^1.2",
                 "psr/container-implementation": "^1.0"
             },
-            "replace": {
-                "zendframework/zend-servicemanager": "^3.4.0"
-            },
             "require-dev": {
                 "composer/package-versions-deprecated": "^1.0",
-                "laminas/laminas-coding-standard": "~1.0.0",
+                "laminas/laminas-coding-standard": "~2.2.1",
                 "laminas/laminas-container-config-test": "^0.3",
-                "laminas/laminas-dependency-plugin": "^2.1",
-                "mikey179/vfsstream": "^1.6.8",
-                "ocramius/proxy-manager": "^2.2.3",
-                "phpbench/phpbench": "^1.0.0-alpha3",
+                "laminas/laminas-dependency-plugin": "^2.1.2",
+                "mikey179/vfsstream": "^1.6.10@alpha",
+                "ocramius/proxy-manager": "^2.11",
+                "phpbench/phpbench": "^1.1",
                 "phpspec/prophecy-phpunit": "^2.0",
-                "phpunit/phpunit": "^9.4"
+                "phpunit/phpunit": "^9.5.5",
+                "psalm/plugin-phpunit": "^0.16.1",
+                "vimeo/psalm": "^4.8"
             },
             "suggest": {
                 "ocramius/proxy-manager": "ProxyManager ^2.1.1 to handle lazy initialization of services"
@@ -302,7 +301,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-02-03T08:44:41+00:00"
+            "time": "2021-09-18T20:19:36+00:00"
         },
         {
             "name": "laminas/laminas-stdlib",

--- a/composer.lock
+++ b/composer.lock
@@ -735,33 +735,33 @@
         },
         {
             "name": "phpspec/prophecy",
-            "version": "1.13.0",
+            "version": "1.14.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpspec/prophecy.git",
-                "reference": "be1996ed8adc35c3fd795488a653f4b518be70ea"
+                "reference": "d86dfc2e2a3cd366cee475e52c6bb3bbc371aa0e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/be1996ed8adc35c3fd795488a653f4b518be70ea",
-                "reference": "be1996ed8adc35c3fd795488a653f4b518be70ea",
+                "url": "https://api.github.com/repos/phpspec/prophecy/zipball/d86dfc2e2a3cd366cee475e52c6bb3bbc371aa0e",
+                "reference": "d86dfc2e2a3cd366cee475e52c6bb3bbc371aa0e",
                 "shasum": ""
             },
             "require": {
                 "doctrine/instantiator": "^1.2",
-                "php": "^7.2 || ~8.0, <8.1",
+                "php": "^7.2 || ~8.0, <8.2",
                 "phpdocumentor/reflection-docblock": "^5.2",
                 "sebastian/comparator": "^3.0 || ^4.0",
                 "sebastian/recursion-context": "^3.0 || ^4.0"
             },
             "require-dev": {
-                "phpspec/phpspec": "^6.0",
+                "phpspec/phpspec": "^6.0 || ^7.0",
                 "phpunit/phpunit": "^8.0 || ^9.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.11.x-dev"
+                    "dev-master": "1.x-dev"
                 }
             },
             "autoload": {
@@ -796,9 +796,9 @@
             ],
             "support": {
                 "issues": "https://github.com/phpspec/prophecy/issues",
-                "source": "https://github.com/phpspec/prophecy/tree/1.13.0"
+                "source": "https://github.com/phpspec/prophecy/tree/1.14.0"
             },
-            "time": "2021-03-17T13:42:18+00:00"
+            "time": "2021-09-10T09:02:12+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -2425,5 +2425,5 @@
         "php": "^7.3 || ~8.0.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "1.1.0"
+    "plugin-api-version": "2.1.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e9593655194da41b067e4fe9735bf7a1",
+    "content-hash": "67243dbfc4263c15706b8f13dab543bc",
     "packages": [
         {
             "name": "laminas/laminas-zendframework-bridge",
@@ -107,6 +107,76 @@
             "time": "2017-02-14T19:40:03+00:00"
         },
         {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v0.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
+                "reference": "fe390591e0241955f22eb9ba327d137e501c771c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/fe390591e0241955f22eb9ba327d137e501c771c",
+                "reference": "fe390591e0241955f22eb9ba327d137e501c771c",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.0 || ^3.0 || ^4.0"
+            },
+            "require-dev": {
+                "composer/composer": "*",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "sensiolabs/security-checker": "^4.1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "franck.nijhof@dealerdirect.com",
+                    "homepage": "http://www.frenck.nl",
+                    "role": "Developer / IT Manager"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "homepage": "http://www.dealerdirect.com",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
+                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
+            },
+            "time": "2020-12-07T18:04:37+00:00"
+        },
+        {
             "name": "doctrine/instantiator",
             "version": "1.4.0",
             "source": {
@@ -177,31 +247,36 @@
         },
         {
             "name": "laminas/laminas-coding-standard",
-            "version": "1.0.0",
+            "version": "2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-coding-standard.git",
-                "reference": "08880ce2fbfe62d471cd3cb766a91da630b32539"
+                "reference": "bcf6e07fe4690240be7beb6d884d0b0fafa6a251"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-coding-standard/zipball/08880ce2fbfe62d471cd3cb766a91da630b32539",
-                "reference": "08880ce2fbfe62d471cd3cb766a91da630b32539",
+                "url": "https://api.github.com/repos/laminas/laminas-coding-standard/zipball/bcf6e07fe4690240be7beb6d884d0b0fafa6a251",
+                "reference": "bcf6e07fe4690240be7beb6d884d0b0fafa6a251",
                 "shasum": ""
             },
             "require": {
-                "laminas/laminas-zendframework-bridge": "^1.0",
-                "squizlabs/php_codesniffer": "^2.7"
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
+                "php": "^7.3 || ^8.0",
+                "slevomat/coding-standard": "^7.0",
+                "squizlabs/php_codesniffer": "^3.6",
+                "webimpress/coding-standard": "^1.2"
             },
-            "replace": {
-                "zendframework/zend-coding-standard": "self.version"
+            "type": "phpcodesniffer-standard",
+            "autoload": {
+                "psr-4": {
+                    "LaminasCodingStandard\\": "src/LaminasCodingStandard/"
+                }
             },
-            "type": "library",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-3-Clause"
             ],
-            "description": "Laminas coding standard",
+            "description": "Laminas Coding Standard",
             "homepage": "https://laminas.dev",
             "keywords": [
                 "Coding Standard",
@@ -215,7 +290,13 @@
                 "rss": "https://github.com/laminas/laminas-coding-standard/releases.atom",
                 "source": "https://github.com/laminas/laminas-coding-standard"
             },
-            "time": "2019-12-31T16:28:26+00:00"
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2021-05-29T15:53:59+00:00"
         },
         {
             "name": "laminas/laminas-servicemanager",
@@ -812,6 +893,55 @@
                 "source": "https://github.com/phpspec/prophecy/tree/1.14.0"
             },
             "time": "2021-09-10T09:02:12+00:00"
+        },
+        {
+            "name": "phpstan/phpdoc-parser",
+            "version": "1.2.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "dbc093d7af60eff5cd575d2ed761b15ed40bd08e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/dbc093d7af60eff5cd575d2ed761b15ed40bd08e",
+                "reference": "dbc093d7af60eff5cd575d2ed761b15ed40bd08e",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^1.0",
+                "phpstan/phpstan-strict-rules": "^1.0",
+                "phpunit/phpunit": "^9.5",
+                "symfony/process": "^5.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/1.2.0"
+            },
+            "time": "2021-09-16T20:46:02+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -2247,64 +2377,98 @@
             "time": "2020-09-28T06:39:44+00:00"
         },
         {
-            "name": "squizlabs/php_codesniffer",
-            "version": "2.9.2",
+            "name": "slevomat/coding-standard",
+            "version": "7.0.16",
             "source": {
                 "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "2acf168de78487db620ab4bc524135a13cfe6745"
+                "url": "https://github.com/slevomat/coding-standard.git",
+                "reference": "14c324b2f2f0072933036c2f3abaeda16a56dcd3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/2acf168de78487db620ab4bc524135a13cfe6745",
-                "reference": "2acf168de78487db620ab4bc524135a13cfe6745",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/14c324b2f2f0072933036c2f3abaeda16a56dcd3",
+                "reference": "14c324b2f2f0072933036c2f3abaeda16a56dcd3",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
+                "php": "^7.1 || ^8.0",
+                "phpstan/phpdoc-parser": "^1.0.0",
+                "squizlabs/php_codesniffer": "^3.6.1"
+            },
+            "require-dev": {
+                "phing/phing": "2.17.0",
+                "php-parallel-lint/php-parallel-lint": "1.3.1",
+                "phpstan/phpstan": "0.12.99",
+                "phpstan/phpstan-deprecation-rules": "0.12.6",
+                "phpstan/phpstan-phpunit": "0.12.22",
+                "phpstan/phpstan-strict-rules": "0.12.11",
+                "phpunit/phpunit": "7.5.20|8.5.5|9.5.10"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "SlevomatCodingStandard\\": "SlevomatCodingStandard"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
+            "support": {
+                "issues": "https://github.com/slevomat/coding-standard/issues",
+                "source": "https://github.com/slevomat/coding-standard/tree/7.0.16"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/kukulich",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/slevomat/coding-standard",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-10-22T06:56:51+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.6.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "f268ca40d54617c6e06757f83f699775c9b3ff2e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/f268ca40d54617c6e06757f83f699775c9b3ff2e",
+                "reference": "f268ca40d54617c6e06757f83f699775c9b3ff2e",
                 "shasum": ""
             },
             "require": {
                 "ext-simplexml": "*",
                 "ext-tokenizer": "*",
                 "ext-xmlwriter": "*",
-                "php": ">=5.1.2"
+                "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "bin": [
-                "scripts/phpcs",
-                "scripts/phpcbf"
+                "bin/phpcs",
+                "bin/phpcbf"
             ],
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.x-dev"
+                    "dev-master": "3.x-dev"
                 }
-            },
-            "autoload": {
-                "classmap": [
-                    "CodeSniffer.php",
-                    "CodeSniffer/CLI.php",
-                    "CodeSniffer/Exception.php",
-                    "CodeSniffer/File.php",
-                    "CodeSniffer/Fixer.php",
-                    "CodeSniffer/Report.php",
-                    "CodeSniffer/Reporting.php",
-                    "CodeSniffer/Sniff.php",
-                    "CodeSniffer/Tokens.php",
-                    "CodeSniffer/Reports/",
-                    "CodeSniffer/Tokenizers/",
-                    "CodeSniffer/DocGenerators/",
-                    "CodeSniffer/Standards/AbstractPatternSniff.php",
-                    "CodeSniffer/Standards/AbstractScopeSniff.php",
-                    "CodeSniffer/Standards/AbstractVariableSniff.php",
-                    "CodeSniffer/Standards/IncorrectPatternException.php",
-                    "CodeSniffer/Standards/Generic/Sniffs/",
-                    "CodeSniffer/Standards/MySource/Sniffs/",
-                    "CodeSniffer/Standards/PEAR/Sniffs/",
-                    "CodeSniffer/Standards/PSR1/Sniffs/",
-                    "CodeSniffer/Standards/PSR2/Sniffs/",
-                    "CodeSniffer/Standards/Squiz/Sniffs/",
-                    "CodeSniffer/Standards/Zend/Sniffs/"
-                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -2317,7 +2481,7 @@
                 }
             ],
             "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
                 "standards"
@@ -2327,7 +2491,7 @@
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2018-11-07T22:31:41+00:00"
+            "time": "2021-10-11T04:00:11+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -2457,6 +2621,61 @@
                 }
             ],
             "time": "2021-07-28T10:34:58+00:00"
+        },
+        {
+            "name": "webimpress/coding-standard",
+            "version": "1.2.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webimpress/coding-standard.git",
+                "reference": "7a71421c7fc85827488f10c4c510fe80f94d1a74"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webimpress/coding-standard/zipball/7a71421c7fc85827488f10c4c510fe80f94d1a74",
+                "reference": "7a71421c7fc85827488f10c4c510fe80f94d1a74",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3 || ^8.0",
+                "squizlabs/php_codesniffer": "^3.6.1"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5.10"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "dev-master": "1.2.x-dev",
+                "dev-develop": "1.3.x-dev"
+            },
+            "autoload": {
+                "psr-4": {
+                    "WebimpressCodingStandard\\": "src/WebimpressCodingStandard/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "description": "Webimpress Coding Standard",
+            "keywords": [
+                "Coding Standard",
+                "PSR-2",
+                "phpcs",
+                "psr-12",
+                "webimpress"
+            ],
+            "support": {
+                "issues": "https://github.com/webimpress/coding-standard/issues",
+                "source": "https://github.com/webimpress/coding-standard/tree/1.2.3"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/michalbundyra",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-10-28T21:18:17+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/composer.lock
+++ b/composer.lock
@@ -4,27 +4,27 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "64ae8286a40496ca494c4ea4daaca37a",
+    "content-hash": "e9593655194da41b067e4fe9735bf7a1",
     "packages": [
         {
             "name": "laminas/laminas-zendframework-bridge",
-            "version": "1.2.0",
+            "version": "1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-zendframework-bridge.git",
-                "reference": "6cccbddfcfc742eb02158d6137ca5687d92cee32"
+                "reference": "bf180a382393e7db5c1e8d0f2ec0c4af9c724baf"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/6cccbddfcfc742eb02158d6137ca5687d92cee32",
-                "reference": "6cccbddfcfc742eb02158d6137ca5687d92cee32",
+                "url": "https://api.github.com/repos/laminas/laminas-zendframework-bridge/zipball/bf180a382393e7db5c1e8d0f2ec0c4af9c724baf",
+                "reference": "bf180a382393e7db5c1e8d0f2ec0c4af9c724baf",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.3 || ^8.0"
+                "php": "^7.3 || ~8.0.0 || ~8.1.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^5.7 || ^6.5 || ^7.5 || ^8.1 || ^9.3",
+                "phpunit/phpunit": "^9.3",
                 "psalm/plugin-phpunit": "^0.15.1",
                 "squizlabs/php_codesniffer": "^3.5",
                 "vimeo/psalm": "^4.6"
@@ -66,7 +66,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2021-02-25T21:54:58+00:00"
+            "time": "2021-09-03T17:53:30+00:00"
         }
     ],
     "packages-dev": [

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "aacc429ee4b2fc2c3d6023ece1911716",
+    "content-hash": "76f5ca75c4f3fdf36fb3437caf6d49c7",
     "packages": [
         {
             "name": "laminas/laminas-zendframework-bridge",
@@ -422,16 +422,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.10.4",
+            "version": "v4.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "c6d052fc58cb876152f89f532b95a8d7907e7f0e"
+                "reference": "63a79e8daa781cac14e5195e63ed8ae231dd10fd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/c6d052fc58cb876152f89f532b95a8d7907e7f0e",
-                "reference": "c6d052fc58cb876152f89f532b95a8d7907e7f0e",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/63a79e8daa781cac14e5195e63ed8ae231dd10fd",
+                "reference": "63a79e8daa781cac14e5195e63ed8ae231dd10fd",
                 "shasum": ""
             },
             "require": {
@@ -470,20 +470,24 @@
                 "parser",
                 "php"
             ],
-            "time": "2020-12-20T10:01:03+00:00"
+            "support": {
+                "issues": "https://github.com/nikic/PHP-Parser/issues",
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.13.1"
+            },
+            "time": "2021-11-03T20:52:16+00:00"
         },
         {
             "name": "phar-io/manifest",
-            "version": "2.0.1",
+            "version": "2.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phar-io/manifest.git",
-                "reference": "85265efd3af7ba3ca4b2a2c34dbfc5788dd29133"
+                "reference": "97803eca37d319dfa7826cc2437fc020857acb53"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phar-io/manifest/zipball/85265efd3af7ba3ca4b2a2c34dbfc5788dd29133",
-                "reference": "85265efd3af7ba3ca4b2a2c34dbfc5788dd29133",
+                "url": "https://api.github.com/repos/phar-io/manifest/zipball/97803eca37d319dfa7826cc2437fc020857acb53",
+                "reference": "97803eca37d319dfa7826cc2437fc020857acb53",
                 "shasum": ""
             },
             "require": {
@@ -526,7 +530,11 @@
                 }
             ],
             "description": "Component for reading phar.io manifest information from a PHP Archive (PHAR)",
-            "time": "2020-06-27T14:33:11+00:00"
+            "support": {
+                "issues": "https://github.com/phar-io/manifest/issues",
+                "source": "https://github.com/phar-io/manifest/tree/2.0.3"
+            },
+            "time": "2021-07-20T11:28:43+00:00"
         },
         {
             "name": "phar-io/version",
@@ -573,6 +581,10 @@
                 }
             ],
             "description": "Library for handling version information and constraints",
+            "support": {
+                "issues": "https://github.com/phar-io/version/issues",
+                "source": "https://github.com/phar-io/version/tree/3.1.0"
+            },
             "time": "2021-02-23T14:00:09+00:00"
         },
         {
@@ -630,16 +642,16 @@
         },
         {
             "name": "phpdocumentor/reflection-docblock",
-            "version": "5.2.2",
+            "version": "5.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
-                "reference": "069a785b2141f5bcf49f3e353548dc1cce6df556"
+                "reference": "622548b623e81ca6d78b721c5e029f4ce664f170"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/069a785b2141f5bcf49f3e353548dc1cce6df556",
-                "reference": "069a785b2141f5bcf49f3e353548dc1cce6df556",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/622548b623e81ca6d78b721c5e029f4ce664f170",
+                "reference": "622548b623e81ca6d78b721c5e029f4ce664f170",
                 "shasum": ""
             },
             "require": {
@@ -650,7 +662,8 @@
                 "webmozart/assert": "^1.9.1"
             },
             "require-dev": {
-                "mockery/mockery": "~1.3.2"
+                "mockery/mockery": "~1.3.2",
+                "psalm/phar": "^4.8"
             },
             "type": "library",
             "extra": {
@@ -680,22 +693,22 @@
             "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
             "support": {
                 "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
-                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/master"
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/5.3.0"
             },
-            "time": "2020-09-03T19:13:55+00:00"
+            "time": "2021-10-19T17:43:47+00:00"
         },
         {
             "name": "phpdocumentor/type-resolver",
-            "version": "1.4.0",
+            "version": "1.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/phpDocumentor/TypeResolver.git",
-                "reference": "6a467b8989322d92aa1c8bf2bebcc6e5c2ba55c0"
+                "reference": "a12f7e301eb7258bb68acd89d4aefa05c2906cae"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/6a467b8989322d92aa1c8bf2bebcc6e5c2ba55c0",
-                "reference": "6a467b8989322d92aa1c8bf2bebcc6e5c2ba55c0",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/a12f7e301eb7258bb68acd89d4aefa05c2906cae",
+                "reference": "a12f7e301eb7258bb68acd89d4aefa05c2906cae",
                 "shasum": ""
             },
             "require": {
@@ -703,7 +716,8 @@
                 "phpdocumentor/reflection-common": "^2.0"
             },
             "require-dev": {
-                "ext-tokenizer": "*"
+                "ext-tokenizer": "*",
+                "psalm/phar": "^4.8"
             },
             "type": "library",
             "extra": {
@@ -729,9 +743,9 @@
             "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
             "support": {
                 "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
-                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.4.0"
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/1.5.1"
             },
-            "time": "2020-09-17T18:55:26+00:00"
+            "time": "2021-10-02T14:08:47+00:00"
         },
         {
             "name": "phpspec/prophecy",
@@ -802,23 +816,23 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.6",
+            "version": "9.2.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "f6293e1b30a2354e8428e004689671b83871edde"
+                "reference": "f301eb1453c9e7a1bc912ee8b0ea9db22c60223b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/f6293e1b30a2354e8428e004689671b83871edde",
-                "reference": "f6293e1b30a2354e8428e004689671b83871edde",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/f301eb1453c9e7a1bc912ee8b0ea9db22c60223b",
+                "reference": "f301eb1453c9e7a1bc912ee8b0ea9db22c60223b",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
-                "nikic/php-parser": "^4.10.2",
+                "nikic/php-parser": "^4.13.0",
                 "php": ">=7.3",
                 "phpunit/php-file-iterator": "^3.0.3",
                 "phpunit/php-text-template": "^2.0.2",
@@ -865,13 +879,17 @@
                 "testing",
                 "xunit"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.9"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2021-03-28T07:26:59+00:00"
+            "time": "2021-11-19T15:21:02+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -921,6 +939,10 @@
                 "filesystem",
                 "iterator"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/3.0.5"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -980,6 +1002,10 @@
             "keywords": [
                 "process"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/3.1.1"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -1035,6 +1061,10 @@
             "keywords": [
                 "template"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/2.0.4"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -1090,6 +1120,10 @@
             "keywords": [
                 "timer"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/php-timer/issues",
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/5.0.3"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -1100,16 +1134,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.4",
+            "version": "9.5.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "c73c6737305e779771147af66c96ca6a7ed8a741"
+                "reference": "c814a05837f2edb0d1471d6e3f4ab3501ca3899a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c73c6737305e779771147af66c96ca6a7ed8a741",
-                "reference": "c73c6737305e779771147af66c96ca6a7ed8a741",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/c814a05837f2edb0d1471d6e3f4ab3501ca3899a",
+                "reference": "c814a05837f2edb0d1471d6e3f4ab3501ca3899a",
                 "shasum": ""
             },
             "require": {
@@ -1121,11 +1155,11 @@
                 "ext-xml": "*",
                 "ext-xmlwriter": "*",
                 "myclabs/deep-copy": "^1.10.1",
-                "phar-io/manifest": "^2.0.1",
+                "phar-io/manifest": "^2.0.3",
                 "phar-io/version": "^3.0.2",
                 "php": ">=7.3",
                 "phpspec/prophecy": "^1.12.1",
-                "phpunit/php-code-coverage": "^9.2.3",
+                "phpunit/php-code-coverage": "^9.2.7",
                 "phpunit/php-file-iterator": "^3.0.5",
                 "phpunit/php-invoker": "^3.1.1",
                 "phpunit/php-text-template": "^2.0.3",
@@ -1139,7 +1173,7 @@
                 "sebastian/global-state": "^5.0.1",
                 "sebastian/object-enumerator": "^4.0.3",
                 "sebastian/resource-operations": "^3.0.3",
-                "sebastian/type": "^2.3",
+                "sebastian/type": "^2.3.4",
                 "sebastian/version": "^3.0.2"
             },
             "require-dev": {
@@ -1185,6 +1219,10 @@
                 "testing",
                 "xunit"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/phpunit/issues",
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.10"
+            },
             "funding": [
                 {
                     "url": "https://phpunit.de/donate.html",
@@ -1195,7 +1233,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2021-03-23T07:16:29+00:00"
+            "time": "2021-09-25T07:38:51+00:00"
         },
         {
             "name": "psr/container",
@@ -1289,6 +1327,10 @@
             ],
             "description": "Library for parsing CLI options",
             "homepage": "https://github.com/sebastianbergmann/cli-parser",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/1.0.1"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -1341,6 +1383,10 @@
             ],
             "description": "Collection of value objects that represent the PHP code units",
             "homepage": "https://github.com/sebastianbergmann/code-unit",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit/tree/1.0.8"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -1392,6 +1438,10 @@
             ],
             "description": "Looks up which function or method a line of code belongs to",
             "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
+                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/2.0.3"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -1462,6 +1512,10 @@
                 "compare",
                 "equality"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/comparator/issues",
+                "source": "https://github.com/sebastianbergmann/comparator/tree/4.0.6"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -1515,6 +1569,10 @@
             ],
             "description": "Library for calculating the complexity of PHP code units",
             "homepage": "https://github.com/sebastianbergmann/complexity",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/complexity/issues",
+                "source": "https://github.com/sebastianbergmann/complexity/tree/2.0.2"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -1577,6 +1635,10 @@
                 "unidiff",
                 "unified diff"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/diff/issues",
+                "source": "https://github.com/sebastianbergmann/diff/tree/4.0.4"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -1636,6 +1698,10 @@
                 "environment",
                 "hhvm"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/environment/issues",
+                "source": "https://github.com/sebastianbergmann/environment/tree/5.1.3"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -1646,16 +1712,16 @@
         },
         {
             "name": "sebastian/exporter",
-            "version": "4.0.3",
+            "version": "4.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "d89cc98761b8cb5a1a235a6b703ae50d34080e65"
+                "reference": "65e8b7db476c5dd267e65eea9cab77584d3cfff9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/d89cc98761b8cb5a1a235a6b703ae50d34080e65",
-                "reference": "d89cc98761b8cb5a1a235a6b703ae50d34080e65",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/65e8b7db476c5dd267e65eea9cab77584d3cfff9",
+                "reference": "65e8b7db476c5dd267e65eea9cab77584d3cfff9",
                 "shasum": ""
             },
             "require": {
@@ -1704,31 +1770,35 @@
                 }
             ],
             "description": "Provides the functionality to export PHP variables for visualization",
-            "homepage": "http://www.github.com/sebastianbergmann/exporter",
+            "homepage": "https://www.github.com/sebastianbergmann/exporter",
             "keywords": [
                 "export",
                 "exporter"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/exporter/issues",
+                "source": "https://github.com/sebastianbergmann/exporter/tree/4.0.4"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-09-28T05:24:23+00:00"
+            "time": "2021-11-11T14:18:36+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "5.0.2",
+            "version": "5.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "a90ccbddffa067b51f574dea6eb25d5680839455"
+                "reference": "23bd5951f7ff26f12d4e3242864df3e08dec4e49"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/a90ccbddffa067b51f574dea6eb25d5680839455",
-                "reference": "a90ccbddffa067b51f574dea6eb25d5680839455",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/23bd5951f7ff26f12d4e3242864df3e08dec4e49",
+                "reference": "23bd5951f7ff26f12d4e3242864df3e08dec4e49",
                 "shasum": ""
             },
             "require": {
@@ -1769,13 +1839,17 @@
             "keywords": [
                 "global state"
             ],
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/global-state/issues",
+                "source": "https://github.com/sebastianbergmann/global-state/tree/5.0.3"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T15:55:19+00:00"
+            "time": "2021-06-11T13:31:12+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
@@ -1822,6 +1896,10 @@
             ],
             "description": "Library for counting the lines of code in PHP source code",
             "homepage": "https://github.com/sebastianbergmann/lines-of-code",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/1.0.3"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -1875,6 +1953,10 @@
             ],
             "description": "Traverses array structures and object graphs to enumerate all referenced objects",
             "homepage": "https://github.com/sebastianbergmann/object-enumerator/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/4.0.4"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -1926,6 +2008,10 @@
             ],
             "description": "Allows reflection of object attributes, including inherited and non-public ones",
             "homepage": "https://github.com/sebastianbergmann/object-reflector/",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/2.0.4"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -1985,6 +2071,10 @@
             ],
             "description": "Provides functionality to recursively process PHP variables",
             "homepage": "http://www.github.com/sebastianbergmann/recursion-context",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/4.0.4"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -2036,6 +2126,10 @@
             ],
             "description": "Provides a list of PHP built-in functions that operate on resources",
             "homepage": "https://www.github.com/sebastianbergmann/resource-operations",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/resource-operations/issues",
+                "source": "https://github.com/sebastianbergmann/resource-operations/tree/3.0.3"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -2046,16 +2140,16 @@
         },
         {
             "name": "sebastian/type",
-            "version": "2.3.1",
+            "version": "2.3.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "81cd61ab7bbf2de744aba0ea61fae32f721df3d2"
+                "reference": "b8cd8a1c753c90bc1a0f5372170e3e489136f914"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/81cd61ab7bbf2de744aba0ea61fae32f721df3d2",
-                "reference": "81cd61ab7bbf2de744aba0ea61fae32f721df3d2",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/b8cd8a1c753c90bc1a0f5372170e3e489136f914",
+                "reference": "b8cd8a1c753c90bc1a0f5372170e3e489136f914",
                 "shasum": ""
             },
             "require": {
@@ -2088,13 +2182,17 @@
             ],
             "description": "Collection of value objects that represent the types of the PHP type system",
             "homepage": "https://github.com/sebastianbergmann/type",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/type/issues",
+                "source": "https://github.com/sebastianbergmann/type/tree/2.3.4"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
                 }
             ],
-            "time": "2020-10-26T13:18:59+00:00"
+            "time": "2021-06-15T12:49:02+00:00"
         },
         {
             "name": "sebastian/version",
@@ -2137,6 +2235,10 @@
             ],
             "description": "Library that helps with managing the version number of Git-hosted PHP projects",
             "homepage": "https://github.com/sebastianbergmann/version",
+            "support": {
+                "issues": "https://github.com/sebastianbergmann/version/issues",
+                "source": "https://github.com/sebastianbergmann/version/tree/3.0.2"
+            },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
@@ -2230,16 +2332,16 @@
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.22.1",
+            "version": "v1.23.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "c6c942b1ac76c82448322025e084cadc56048b4e"
+                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/c6c942b1ac76c82448322025e084cadc56048b4e",
-                "reference": "c6c942b1ac76c82448322025e084cadc56048b4e",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/46cd95797e9df938fdd2b03693b5fca5e64b01ce",
+                "reference": "46cd95797e9df938fdd2b03693b5fca5e64b01ce",
                 "shasum": ""
             },
             "require": {
@@ -2251,7 +2353,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "1.22-dev"
+                    "dev-main": "1.23-dev"
                 },
                 "thanks": {
                     "name": "symfony/polyfill",
@@ -2289,7 +2391,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.22.1"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.23.0"
             },
             "funding": [
                 {
@@ -2305,20 +2407,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2021-01-07T16:49:33+00:00"
+            "time": "2021-02-19T12:13:01+00:00"
         },
         {
             "name": "theseer/tokenizer",
-            "version": "1.2.0",
+            "version": "1.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "75a63c33a8577608444246075ea0af0d052e452a"
+                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/75a63c33a8577608444246075ea0af0d052e452a",
-                "reference": "75a63c33a8577608444246075ea0af0d052e452a",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/34a41e998c2183e22995f158c581e7b5e755ab9e",
+                "reference": "34a41e998c2183e22995f158c581e7b5e755ab9e",
                 "shasum": ""
             },
             "require": {
@@ -2347,7 +2449,7 @@
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
                 "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/master"
+                "source": "https://github.com/theseer/tokenizer/tree/1.2.1"
             },
             "funding": [
                 {
@@ -2355,7 +2457,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-07-12T23:59:07+00:00"
+            "time": "2021-07-28T10:34:58+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "76f5ca75c4f3fdf36fb3437caf6d49c7",
+    "content-hash": "0ae0dc9fad728595fa397c5c1c7e9cb7",
     "packages": [
         {
             "name": "laminas/laminas-zendframework-bridge",
@@ -2524,7 +2524,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "^7.3 || ~8.0.0"
+        "php": "~7.4.0 || ~8.0.0"
     },
     "platform-dev": [],
     "plugin-api-version": "2.1.0"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "67243dbfc4263c15706b8f13dab543bc",
+    "content-hash": "79eaf63449533778c85f63337c40378a",
     "packages": [
         {
             "name": "laminas/laminas-zendframework-bridge",
@@ -2742,7 +2742,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": "~7.4.0 || ~8.0.0"
+        "php": "~7.4.0 || ~8.0.0 || ~8.1.0"
     },
     "platform-dev": [],
     "plugin-api-version": "2.1.0"

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <ruleset name="Laminas Coding Standard">
-    <rule ref="./vendor/laminas/laminas-coding-standard/ruleset.xml"/>
+    <rule ref="./vendor/laminas/laminas-coding-standard/src/LaminasCodingStandard/ruleset.xml"/>
 
     <file>src</file>
     <file>test</file>

--- a/src/Acl.php
+++ b/src/Acl.php
@@ -8,6 +8,8 @@ declare(strict_types=1);
 
 namespace Laminas\Permissions\Acl;
 
+use Exception as PHPException;
+
 use function array_key_exists;
 use function array_keys;
 use function array_merge;
@@ -24,22 +26,22 @@ class Acl implements AclInterface
     /**
      * Rule type: allow
      */
-    const TYPE_ALLOW = 'TYPE_ALLOW';
+    public const TYPE_ALLOW = 'TYPE_ALLOW';
 
     /**
      * Rule type: deny
      */
-    const TYPE_DENY = 'TYPE_DENY';
+    public const TYPE_DENY = 'TYPE_DENY';
 
     /**
      * Rule operation: add
      */
-    const OP_ADD = 'OP_ADD';
+    public const OP_ADD = 'OP_ADD';
 
     /**
      * Rule operation: remove
      */
-    const OP_REMOVE = 'OP_REMOVE';
+    public const OP_REMOVE = 'OP_REMOVE';
 
     /**
      * Role registry
@@ -256,7 +258,7 @@ class Acl implements AclInterface
                     $resourceParentId = $parent;
                 }
                 $resourceParent = $this->getResource($resourceParentId);
-            } catch (\Exception $e) {
+            } catch (PHPException $e) {
                 throw new Exception\InvalidArgumentException(sprintf(
                     'Parent Resource id "%s" does not exist',
                     $resourceParentId
@@ -327,7 +329,7 @@ class Acl implements AclInterface
      * inherits from $inherit through its ancestor Resources.
      *
      * @param  Resource\ResourceInterface|string    $resource
-     * @param  Resource\ResourceInterface|string    inherit
+     * @param  Resource\ResourceInterface|string    $inherit
      * @param  bool                              $onlyParent
      * @throws Exception\InvalidArgumentException
      * @return bool
@@ -682,10 +684,10 @@ class Acl implements AclInterface
 
         $children = $this->resources[$id]['children'];
         foreach ($children as $child) {
-            $child_return                          = $this->getChildResources($child);
-            $child_return[$child->getResourceId()] = $child;
+            $childReturn                          = $this->getChildResources($child);
+            $childReturn[$child->getResourceId()] = $child;
 
-            $return = array_merge($return, $child_return);
+            $return = array_merge($return, $childReturn);
         }
 
         return $return;
@@ -838,8 +840,6 @@ class Acl implements AclInterface
                 }
             }
         }
-
-        return;
     }
 
     /**
@@ -878,8 +878,6 @@ class Acl implements AclInterface
         foreach ($this->getRoleRegistry()->getParents($role) as $roleParent) {
             $dfs['stack'][] = $roleParent;
         }
-
-        return;
     }
 
     /**
@@ -919,8 +917,6 @@ class Acl implements AclInterface
                 }
             }
         }
-
-        return;
     }
 
     /**
@@ -966,8 +962,6 @@ class Acl implements AclInterface
         foreach ($this->getRoleRegistry()->getParents($role) as $roleParent) {
             $dfs['stack'][] = $roleParent;
         }
-
-        return;
     }
 
     /**

--- a/src/Acl.php
+++ b/src/Acl.php
@@ -1,10 +1,10 @@
 <?php
 
-declare(strict_types=1);
-
 /**
- * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
+ * @see https://github.com/laminas/laminas-permissions-acl for the canonical source repository
  */
+
+declare(strict_types=1);
 
 namespace Laminas\Permissions\Acl;
 

--- a/src/AclInterface.php
+++ b/src/AclInterface.php
@@ -1,10 +1,10 @@
 <?php
 
-declare(strict_types=1);
-
 /**
- * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
+ * @see https://github.com/laminas/laminas-permissions-acl for the canonical source repository
  */
+
+declare(strict_types=1);
 
 namespace Laminas\Permissions\Acl;
 

--- a/src/AclInterface.php
+++ b/src/AclInterface.php
@@ -1,9 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
- * @copyright https://github.com/laminas/laminas-permissions-acl/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-permissions-acl/blob/master/LICENSE.md New BSD License
  */
 
 namespace Laminas\Permissions\Acl;

--- a/src/Assertion/AssertionAggregate.php
+++ b/src/Assertion/AssertionAggregate.php
@@ -1,10 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
- * @copyright https://github.com/laminas/laminas-permissions-acl/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-permissions-acl/blob/master/LICENSE.md New BSD License
  */
+
 namespace Laminas\Permissions\Acl\Assertion;
 
 use Laminas\Permissions\Acl\Acl;
@@ -12,6 +13,8 @@ use Laminas\Permissions\Acl\Exception\InvalidArgumentException;
 use Laminas\Permissions\Acl\Exception\RuntimeException;
 use Laminas\Permissions\Acl\Resource\ResourceInterface;
 use Laminas\Permissions\Acl\Role\RoleInterface;
+
+use function class_exists;
 
 class AssertionAggregate implements AssertionInterface
 {
@@ -21,10 +24,7 @@ class AssertionAggregate implements AssertionInterface
 
     protected $assertions = [];
 
-    /**
-     *
-     * @var $manager AssertionManager
-     */
+    /** @var $manager AssertionManager */
     protected $assertionManager;
 
     protected $mode = self::MODE_ALL;
@@ -34,7 +34,6 @@ class AssertionAggregate implements AssertionInterface
      *
      * @param AssertionInterface|string $assertion
      *    if string, must match a AssertionManager declared service (checked later)
-     *
      * @return self
      */
     public function addAssertion($assertion)
@@ -66,9 +65,6 @@ class AssertionAggregate implements AssertionInterface
     }
 
     /**
-     *
-     * @param AssertionManager $manager
-     *
      * @return self
      */
     public function setAssertionManager(AssertionManager $manager)
@@ -94,7 +90,6 @@ class AssertionAggregate implements AssertionInterface
      * @param string $mode
      *    indicates how assertion chain result should interpreted (either 'all' or 'at_least_one')
      * @throws InvalidArgumentException
-     *
      * @return self
      */
     public function setMode($mode)
@@ -126,8 +121,8 @@ class AssertionAggregate implements AssertionInterface
      */
     public function assert(
         Acl $acl,
-        RoleInterface $role = null,
-        ResourceInterface $resource = null,
+        ?RoleInterface $role = null,
+        ?ResourceInterface $resource = null,
         $privilege = null
     ) {
         // check if assertions are set

--- a/src/Assertion/AssertionAggregate.php
+++ b/src/Assertion/AssertionAggregate.php
@@ -1,10 +1,10 @@
 <?php
 
-declare(strict_types=1);
-
 /**
- * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
+ * @see https://github.com/laminas/laminas-permissions-acl for the canonical source repository
  */
+
+declare(strict_types=1);
 
 namespace Laminas\Permissions\Acl\Assertion;
 

--- a/src/Assertion/AssertionInterface.php
+++ b/src/Assertion/AssertionInterface.php
@@ -1,9 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
- * @copyright https://github.com/laminas/laminas-permissions-acl/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-permissions-acl/blob/master/LICENSE.md New BSD License
  */
 
 namespace Laminas\Permissions\Acl\Assertion;
@@ -21,11 +21,8 @@ interface AssertionInterface
      * $role, $resource, or $privilege parameters are null, it means that the query applies to all Roles, Resources, or
      * privileges, respectively.
      *
-     * @param  Acl                        $acl
-     * @param  RoleInterface         $role
-     * @param  ResourceInterface $resource
      * @param  string                         $privilege
      * @return bool
      */
-    public function assert(Acl $acl, RoleInterface $role = null, ResourceInterface $resource = null, $privilege = null);
+    public function assert(Acl $acl, ?RoleInterface $role = null, ?ResourceInterface $resource = null, $privilege = null);
 }

--- a/src/Assertion/AssertionInterface.php
+++ b/src/Assertion/AssertionInterface.php
@@ -20,9 +20,11 @@ interface AssertionInterface
      * This method is passed the ACL, Role, Resource, and privilege to which the authorization query applies. If the
      * $role, $resource, or $privilege parameters are null, it means that the query applies to all Roles, Resources, or
      * privileges, respectively.
-     *
-     * @param  string                         $privilege
-     * @return bool
      */
-    public function assert(Acl $acl, ?RoleInterface $role = null, ?ResourceInterface $resource = null, $privilege = null);
+    public function assert(
+        Acl $acl,
+        ?RoleInterface $role = null,
+        ?ResourceInterface $resource = null,
+        ?string $privilege = null
+    ): bool;
 }

--- a/src/Assertion/AssertionInterface.php
+++ b/src/Assertion/AssertionInterface.php
@@ -1,10 +1,10 @@
 <?php
 
-declare(strict_types=1);
-
 /**
- * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
+ * @see https://github.com/laminas/laminas-permissions-acl for the canonical source repository
  */
+
+declare(strict_types=1);
 
 namespace Laminas\Permissions\Acl\Assertion;
 

--- a/src/Assertion/AssertionManager.php
+++ b/src/Assertion/AssertionManager.php
@@ -19,6 +19,7 @@ use function sprintf;
 
 class AssertionManager extends AbstractPluginManager
 {
+    /** @var mixed */
     protected $instanceOf = AssertionInterface::class;
 
     /**
@@ -36,7 +37,9 @@ class AssertionManager extends AbstractPluginManager
                 '%s can only create instances of %s; %s is invalid',
                 static::class,
                 $this->instanceOf,
+                // phpcs:disable SlevomatCodingStandard.Classes.ModernClassNameReference
                 is_object($instance) ? get_class($instance) : gettype($instance)
+                // phpcs:enable
             ));
         }
     }

--- a/src/Assertion/AssertionManager.php
+++ b/src/Assertion/AssertionManager.php
@@ -1,15 +1,21 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
- * @copyright https://github.com/laminas/laminas-permissions-acl/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-permissions-acl/blob/master/LICENSE.md New BSD License
  */
+
 namespace Laminas\Permissions\Acl\Assertion;
 
 use Laminas\Permissions\Acl\Exception\InvalidArgumentException;
 use Laminas\ServiceManager\AbstractPluginManager;
 use Laminas\ServiceManager\Exception\InvalidServiceException;
+
+use function get_class;
+use function gettype;
+use function is_object;
+use function sprintf;
 
 class AssertionManager extends AbstractPluginManager
 {
@@ -28,9 +34,9 @@ class AssertionManager extends AbstractPluginManager
         if (! $instance instanceof $this->instanceOf) {
             throw new InvalidServiceException(sprintf(
                 '%s can only create instances of %s; %s is invalid',
-                get_class($this),
+                static::class,
                 $this->instanceOf,
-                (is_object($instance) ? get_class($instance) : gettype($instance))
+                is_object($instance) ? get_class($instance) : gettype($instance)
             ));
         }
     }
@@ -40,9 +46,10 @@ class AssertionManager extends AbstractPluginManager
      *
      * Proxies to `validate()`.
      *
+     * @deprecated Please use {@see AssertionManager::validate()} instead.
+     *
      * @param mixed $instance
      * @throws InvalidArgumentException
-     * @deprecated Please use {@see AssertionManager::validate()} instead.
      */
     public function validatePlugin($instance)
     {

--- a/src/Assertion/AssertionManager.php
+++ b/src/Assertion/AssertionManager.php
@@ -1,10 +1,10 @@
 <?php
 
-declare(strict_types=1);
-
 /**
- * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
+ * @see https://github.com/laminas/laminas-permissions-acl for the canonical source repository
  */
+
+declare(strict_types=1);
 
 namespace Laminas\Permissions\Acl\Assertion;
 

--- a/src/Assertion/CallbackAssertion.php
+++ b/src/Assertion/CallbackAssertion.php
@@ -1,10 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
- * @copyright https://github.com/laminas/laminas-permissions-acl/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-permissions-acl/blob/master/LICENSE.md New BSD License
  */
+
 namespace Laminas\Permissions\Acl\Assertion;
 
 use Laminas\Permissions\Acl\Acl;
@@ -12,11 +13,12 @@ use Laminas\Permissions\Acl\Exception\InvalidArgumentException;
 use Laminas\Permissions\Acl\Resource\ResourceInterface;
 use Laminas\Permissions\Acl\Role\RoleInterface;
 
+use function call_user_func;
+use function is_callable;
+
 class CallbackAssertion implements AssertionInterface
 {
-    /**
-     * @var callable
-     */
+    /** @var callable */
     protected $callback;
 
     /**
@@ -40,17 +42,13 @@ class CallbackAssertion implements AssertionInterface
      * that the query applies to all Roles, Resources, or privileges,
      * respectively.
      *
-     * @param Acl               $acl
-     * @param RoleInterface     $role
-     * @param ResourceInterface $resource
      * @param string            $privilege
-     *
      * @return bool
      */
     public function assert(
         Acl $acl,
-        RoleInterface $role = null,
-        ResourceInterface $resource = null,
+        ?RoleInterface $role = null,
+        ?ResourceInterface $resource = null,
         $privilege = null
     ) {
         return (bool) call_user_func($this->callback, $acl, $role, $resource, $privilege);

--- a/src/Assertion/CallbackAssertion.php
+++ b/src/Assertion/CallbackAssertion.php
@@ -1,10 +1,10 @@
 <?php
 
-declare(strict_types=1);
-
 /**
- * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
+ * @see https://github.com/laminas/laminas-permissions-acl for the canonical source repository
  */
+
+declare(strict_types=1);
 
 namespace Laminas\Permissions\Acl\Assertion;
 

--- a/src/Assertion/CallbackAssertion.php
+++ b/src/Assertion/CallbackAssertion.php
@@ -41,16 +41,13 @@ class CallbackAssertion implements AssertionInterface
      * If the $role, $resource, or $privilege parameters are null, it means
      * that the query applies to all Roles, Resources, or privileges,
      * respectively.
-     *
-     * @param string            $privilege
-     * @return bool
      */
     public function assert(
         Acl $acl,
         ?RoleInterface $role = null,
         ?ResourceInterface $resource = null,
-        $privilege = null
-    ) {
+        ?string $privilege = null
+    ): bool {
         return (bool) call_user_func($this->callback, $acl, $role, $resource, $privilege);
     }
 }

--- a/src/Assertion/Exception/InvalidAssertionException.php
+++ b/src/Assertion/Exception/InvalidAssertionException.php
@@ -1,8 +1,12 @@
 <?php
+
+declare(strict_types=1);
+
 namespace Laminas\Permissions\Acl\Assertion\Exception;
 
+use InvalidArgumentException;
 use Laminas\Permissions\Acl\Exception\ExceptionInterface;
 
-class InvalidAssertionException extends \InvalidArgumentException implements ExceptionInterface
+class InvalidAssertionException extends InvalidArgumentException implements ExceptionInterface
 {
 }

--- a/src/Assertion/ExpressionAssertion.php
+++ b/src/Assertion/ExpressionAssertion.php
@@ -56,23 +56,23 @@ use function ucwords;
  */
 final class ExpressionAssertion implements AssertionInterface
 {
-    const OPERAND_CONTEXT_PROPERTY = '__context';
+    public const OPERAND_CONTEXT_PROPERTY = '__context';
 
-    const OPERATOR_EQ     = '=';
-    const OPERATOR_NEQ    = '!=';
-    const OPERATOR_LT     = '<';
-    const OPERATOR_LTE    = '<=';
-    const OPERATOR_GT     = '>';
-    const OPERATOR_GTE    = '>=';
-    const OPERATOR_IN     = 'in';
-    const OPERATOR_NIN    = '!in';
-    const OPERATOR_REGEX  = 'regex';
-    const OPERATOR_NREGEX = '!regex';
-    const OPERATOR_SAME   = '===';
-    const OPERATOR_NSAME  = '!==';
+    public const OPERATOR_EQ     = '=';
+    public const OPERATOR_NEQ    = '!=';
+    public const OPERATOR_LT     = '<';
+    public const OPERATOR_LTE    = '<=';
+    public const OPERATOR_GT     = '>';
+    public const OPERATOR_GTE    = '>=';
+    public const OPERATOR_IN     = 'in';
+    public const OPERATOR_NIN    = '!in';
+    public const OPERATOR_REGEX  = 'regex';
+    public const OPERATOR_NREGEX = '!regex';
+    public const OPERATOR_SAME   = '===';
+    public const OPERATOR_NSAME  = '!==';
 
     /** @var array */
-    private static $validOperators = [
+    private static array $validOperators = [
         self::OPERATOR_EQ,
         self::OPERATOR_NEQ,
         self::OPERATOR_LT,
@@ -90,8 +90,7 @@ final class ExpressionAssertion implements AssertionInterface
     /** @var mixed */
     private $left;
 
-    /** @var string */
-    private $operator;
+    private string $operator;
 
     /** @var mixed */
     private $right;
@@ -118,8 +117,8 @@ final class ExpressionAssertion implements AssertionInterface
      * @param string $operator One of the OPERATOR constants (or their values)
      * @param mixed|array $right See the class description for valid values.
      * @return self
-     * @throws InvalidAssertionException if either operand is invalid.
-     * @throws InvalidAssertionException if the operator is not supported.
+     * @throws InvalidAssertionException If either operand is invalid.
+     * @throws InvalidAssertionException If the operator is not supported.
      */
     public static function fromProperties($left, $operator, $right)
     {
@@ -140,9 +139,9 @@ final class ExpressionAssertion implements AssertionInterface
      *     See the class description for valid values for the left and right
      *     hand side values.
      * @return self
-     * @throws InvalidAssertionException if missing one of the required keys.
-     * @throws InvalidAssertionException if either operand is invalid.
-     * @throws InvalidAssertionException if the operator is not supported.
+     * @throws InvalidAssertionException If missing one of the required keys.
+     * @throws InvalidAssertionException If either operand is invalid.
+     * @throws InvalidAssertionException If the operator is not supported.
      */
     public static function fromArray(array $expression)
     {
@@ -163,7 +162,7 @@ final class ExpressionAssertion implements AssertionInterface
 
     /**
      * @param mixed|array $operand
-     * @throws InvalidAssertionException if the operand is invalid.
+     * @throws InvalidAssertionException If the operand is invalid.
      */
     private static function validateOperand($operand)
     {
@@ -175,10 +174,9 @@ final class ExpressionAssertion implements AssertionInterface
     }
 
     /**
-     * @param string $operand
-     * @throws InvalidAssertionException if the operator is not supported.
+     * @throws InvalidAssertionException If the operator is not supported.
      */
-    private static function validateOperator($operator)
+    private static function validateOperator(string $operator)
     {
         if (! in_array($operator, self::$validOperators, true)) {
             throw new InvalidAssertionException('Provided expression assertion operator is not supported');
@@ -188,8 +186,12 @@ final class ExpressionAssertion implements AssertionInterface
     /**
      * {@inheritDoc}
      */
-    public function assert(Acl $acl, ?RoleInterface $role = null, ?ResourceInterface $resource = null, $privilege = null)
-    {
+    public function assert(
+        Acl $acl,
+        ?RoleInterface $role = null,
+        ?ResourceInterface $resource = null,
+        ?string $privilege = null
+    ): bool {
         return $this->evaluate([
             'acl'       => $acl,
             'role'      => $role,
@@ -232,12 +234,12 @@ final class ExpressionAssertion implements AssertionInterface
     }
 
     /**
-     * @param mixed|array
+     * @param mixed|array $operand
      * @param array $context Contains the acl, privilege, role, and resource
      *     being tested currently.
      * @return mixed
-     * @throws RuntimeException if object cannot be resolved in context.
-     * @throws RuntimeException if property cannot be resolved.
+     * @throws RuntimeException If object cannot be resolved in context.
+     * @throws RuntimeException If property cannot be resolved.
      */
     private function resolveOperandValue($operand, array $context)
     {
@@ -268,8 +270,8 @@ final class ExpressionAssertion implements AssertionInterface
      * @param string $objectName Name of object in context to use.
      * @param string $field
      * @return mixed
-     * @throws RuntimeException if object cannot be resolved in context.
-     * @throws RuntimeException if property cannot be resolved.
+     * @throws RuntimeException If object cannot be resolved in context.
+     * @throws RuntimeException If property cannot be resolved.
      */
     private function getObjectFieldValue(array $context, $objectName, $field)
     {
@@ -307,17 +309,16 @@ final class ExpressionAssertion implements AssertionInterface
 
     /**
      * @param mixed $left
-     * @param string $right
      * @param mixed $right
-     * @throws RuntimeException if operand is not supported.
+     * @throws RuntimeException If operand is not supported.
      */
-    private static function evaluateExpression($left, $operator, $right)
+    private static function evaluateExpression($left, string $operator, $right): bool
     {
         switch ($operator) {
             case self::OPERATOR_EQ:
-                return $left == $right;
+                return $left == $right; // phpcs:ignore -- strict checking
             case self::OPERATOR_NEQ:
-                return $left != $right;
+                return $left != $right; // phpcs:ignore -- strict checking
             case self::OPERATOR_LT:
                 return $left < $right;
             case self::OPERATOR_LTE:
@@ -343,10 +344,8 @@ final class ExpressionAssertion implements AssertionInterface
 
     /**
      * @param object $object
-     * @param string $field
-     * @return mixed
      */
-    private function propertyExists($object, $property)
+    private function propertyExists($object, string $property): bool
     {
         if (! property_exists($object, $property)) {
             return false;

--- a/src/Assertion/ExpressionAssertion.php
+++ b/src/Assertion/ExpressionAssertion.php
@@ -1,9 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
- * @copyright https://github.com/laminas/laminas-permissions-acl/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-permissions-acl/blob/master/LICENSE.md New BSD License
  */
 
 namespace Laminas\Permissions\Acl\Assertion;
@@ -14,6 +14,22 @@ use Laminas\Permissions\Acl\Exception\RuntimeException;
 use Laminas\Permissions\Acl\Resource\ResourceInterface;
 use Laminas\Permissions\Acl\Role\RoleInterface;
 use ReflectionProperty;
+
+use function array_flip;
+use function array_intersect_key;
+use function count;
+use function explode;
+use function in_array;
+use function is_array;
+use function is_string;
+use function method_exists;
+use function preg_match;
+use function property_exists;
+use function sprintf;
+use function str_replace;
+use function strpos;
+use function strtolower;
+use function ucwords;
 
 /**
  * Create an assertion based on expression rules.
@@ -55,9 +71,7 @@ final class ExpressionAssertion implements AssertionInterface
     const OPERATOR_SAME   = '===';
     const OPERATOR_NSAME  = '!==';
 
-    /**
-     * @var array
-     */
+    /** @var array */
     private static $validOperators = [
         self::OPERATOR_EQ,
         self::OPERATOR_NEQ,
@@ -73,19 +87,13 @@ final class ExpressionAssertion implements AssertionInterface
         self::OPERATOR_NSAME,
     ];
 
-    /**
-     * @var mixed
-     */
+    /** @var mixed */
     private $left;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     private $operator;
 
-    /**
-     * @var mixed
-     */
+    /** @var mixed */
     private $right;
 
     /**
@@ -100,9 +108,9 @@ final class ExpressionAssertion implements AssertionInterface
      */
     private function __construct($left, $operator, $right)
     {
-        $this->left = $left;
+        $this->left     = $left;
         $this->operator = $operator;
-        $this->right = $right;
+        $this->right    = $right;
     }
 
     /**
@@ -180,7 +188,7 @@ final class ExpressionAssertion implements AssertionInterface
     /**
      * {@inheritDoc}
      */
-    public function assert(Acl $acl, RoleInterface $role = null, ResourceInterface $resource = null, $privilege = null)
+    public function assert(Acl $acl, ?RoleInterface $role = null, ?ResourceInterface $resource = null, $privilege = null)
     {
         return $this->evaluate([
             'acl'       => $acl,
@@ -197,7 +205,7 @@ final class ExpressionAssertion implements AssertionInterface
      */
     private function evaluate(array $context)
     {
-        $left = $this->getLeftValue($context);
+        $left  = $this->getLeftValue($context);
         $right = $this->getRightValue($context);
 
         return static::evaluateExpression($left, $this->operator, $right);
@@ -240,7 +248,7 @@ final class ExpressionAssertion implements AssertionInterface
         $contextProperty = $operand[self::OPERAND_CONTEXT_PROPERTY];
 
         if (strpos($contextProperty, '.') !== false) { // property path?
-            list($objectName, $objectField) = explode('.', $contextProperty, 2);
+            [$objectName, $objectField] = explode('.', $contextProperty, 2);
             return $this->getObjectFieldValue($context, $objectName, $objectField);
         }
 
@@ -272,8 +280,8 @@ final class ExpressionAssertion implements AssertionInterface
             ));
         }
 
-        $object = $context[$objectName];
-        $accessors = ['get', 'is'];
+        $object        = $context[$objectName];
+        $accessors     = ['get', 'is'];
         $fieldAccessor = false === strpos($field, '_')
             ? $field
             : str_replace(' ', '', ucwords(str_replace('_', ' ', $field)));

--- a/src/Assertion/ExpressionAssertion.php
+++ b/src/Assertion/ExpressionAssertion.php
@@ -1,10 +1,10 @@
 <?php
 
-declare(strict_types=1);
-
 /**
- * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
+ * @see https://github.com/laminas/laminas-permissions-acl for the canonical source repository
  */
+
+declare(strict_types=1);
 
 namespace Laminas\Permissions\Acl\Assertion;
 

--- a/src/Assertion/OwnershipAssertion.php
+++ b/src/Assertion/OwnershipAssertion.php
@@ -18,8 +18,12 @@ use Laminas\Permissions\Acl\Role\RoleInterface;
  */
 class OwnershipAssertion implements AssertionInterface
 {
-    public function assert(Acl $acl, ?RoleInterface $role = null, ?ResourceInterface $resource = null, $privilege = null)
-    {
+    public function assert(
+        Acl $acl,
+        ?RoleInterface $role = null,
+        ?ResourceInterface $resource = null,
+        ?string $privilege = null
+    ): bool {
         //Assert passes if role or resource is not proprietary
         if (! $role instanceof ProprietaryInterface || ! $resource instanceof ProprietaryInterface) {
             return true;

--- a/src/Assertion/OwnershipAssertion.php
+++ b/src/Assertion/OwnershipAssertion.php
@@ -1,10 +1,10 @@
 <?php
 
-declare(strict_types=1);
-
 /**
- * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
+ * @see https://github.com/laminas/laminas-permissions-acl for the canonical source repository
  */
+
+declare(strict_types=1);
 
 namespace Laminas\Permissions\Acl\Assertion;
 

--- a/src/Assertion/OwnershipAssertion.php
+++ b/src/Assertion/OwnershipAssertion.php
@@ -1,9 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
- * @copyright https://github.com/laminas/laminas-permissions-acl/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-permissions-acl/blob/master/LICENSE.md New BSD License
  */
 
 namespace Laminas\Permissions\Acl\Assertion;
@@ -18,7 +18,7 @@ use Laminas\Permissions\Acl\Role\RoleInterface;
  */
 class OwnershipAssertion implements AssertionInterface
 {
-    public function assert(Acl $acl, RoleInterface $role = null, ResourceInterface $resource = null, $privilege = null)
+    public function assert(Acl $acl, ?RoleInterface $role = null, ?ResourceInterface $resource = null, $privilege = null)
     {
         //Assert passes if role or resource is not proprietary
         if (! $role instanceof ProprietaryInterface || ! $resource instanceof ProprietaryInterface) {
@@ -30,6 +30,6 @@ class OwnershipAssertion implements AssertionInterface
             return true;
         }
 
-        return ($resource->getOwnerId() === $role->getOwnerId());
+        return $resource->getOwnerId() === $role->getOwnerId();
     }
 }

--- a/src/Exception/ExceptionInterface.php
+++ b/src/Exception/ExceptionInterface.php
@@ -1,10 +1,10 @@
 <?php
 
-declare(strict_types=1);
-
 /**
- * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
+ * @see https://github.com/laminas/laminas-permissions-acl for the canonical source repository
  */
+
+declare(strict_types=1);
 
 namespace Laminas\Permissions\Acl\Exception;
 

--- a/src/Exception/ExceptionInterface.php
+++ b/src/Exception/ExceptionInterface.php
@@ -1,9 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
- * @copyright https://github.com/laminas/laminas-permissions-acl/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-permissions-acl/blob/master/LICENSE.md New BSD License
  */
 
 namespace Laminas\Permissions\Acl\Exception;

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -1,10 +1,10 @@
 <?php
 
-declare(strict_types=1);
-
 /**
- * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
+ * @see https://github.com/laminas/laminas-permissions-acl for the canonical source repository
  */
+
+declare(strict_types=1);
 
 namespace Laminas\Permissions\Acl\Exception;
 

--- a/src/Exception/InvalidArgumentException.php
+++ b/src/Exception/InvalidArgumentException.php
@@ -1,9 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
- * @copyright https://github.com/laminas/laminas-permissions-acl/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-permissions-acl/blob/master/LICENSE.md New BSD License
  */
 
 namespace Laminas\Permissions\Acl\Exception;

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -1,10 +1,10 @@
 <?php
 
-declare(strict_types=1);
-
 /**
- * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
+ * @see https://github.com/laminas/laminas-permissions-acl for the canonical source repository
  */
+
+declare(strict_types=1);
 
 namespace Laminas\Permissions\Acl\Exception;
 

--- a/src/Exception/RuntimeException.php
+++ b/src/Exception/RuntimeException.php
@@ -1,9 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
- * @copyright https://github.com/laminas/laminas-permissions-acl/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-permissions-acl/blob/master/LICENSE.md New BSD License
  */
 
 namespace Laminas\Permissions\Acl\Exception;

--- a/src/ProprietaryInterface.php
+++ b/src/ProprietaryInterface.php
@@ -1,10 +1,10 @@
 <?php
 
-declare(strict_types=1);
-
 /**
- * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
+ * @see https://github.com/laminas/laminas-permissions-acl for the canonical source repository
  */
+
+declare(strict_types=1);
 
 namespace Laminas\Permissions\Acl;
 

--- a/src/ProprietaryInterface.php
+++ b/src/ProprietaryInterface.php
@@ -1,9 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
- * @copyright https://github.com/laminas/laminas-permissions-acl/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-permissions-acl/blob/master/LICENSE.md New BSD License
  */
 
 namespace Laminas\Permissions\Acl;

--- a/src/Resource/GenericResource.php
+++ b/src/Resource/GenericResource.php
@@ -1,10 +1,10 @@
 <?php
 
-declare(strict_types=1);
-
 /**
- * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
+ * @see https://github.com/laminas/laminas-permissions-acl for the canonical source repository
  */
+
+declare(strict_types=1);
 
 namespace Laminas\Permissions\Acl\Resource;
 

--- a/src/Resource/GenericResource.php
+++ b/src/Resource/GenericResource.php
@@ -1,9 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
- * @copyright https://github.com/laminas/laminas-permissions-acl/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-permissions-acl/blob/master/LICENSE.md New BSD License
  */
 
 namespace Laminas\Permissions\Acl\Resource;

--- a/src/Resource/ResourceInterface.php
+++ b/src/Resource/ResourceInterface.php
@@ -1,10 +1,10 @@
 <?php
 
-declare(strict_types=1);
-
 /**
- * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
+ * @see https://github.com/laminas/laminas-permissions-acl for the canonical source repository
  */
+
+declare(strict_types=1);
 
 namespace Laminas\Permissions\Acl\Resource;
 

--- a/src/Resource/ResourceInterface.php
+++ b/src/Resource/ResourceInterface.php
@@ -1,9 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
- * @copyright https://github.com/laminas/laminas-permissions-acl/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-permissions-acl/blob/master/LICENSE.md New BSD License
  */
 
 namespace Laminas\Permissions\Acl\Resource;

--- a/src/Role/GenericRole.php
+++ b/src/Role/GenericRole.php
@@ -1,10 +1,10 @@
 <?php
 
-declare(strict_types=1);
-
 /**
- * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
+ * @see https://github.com/laminas/laminas-permissions-acl for the canonical source repository
  */
+
+declare(strict_types=1);
 
 namespace Laminas\Permissions\Acl\Role;
 

--- a/src/Role/GenericRole.php
+++ b/src/Role/GenericRole.php
@@ -1,9 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
- * @copyright https://github.com/laminas/laminas-permissions-acl/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-permissions-acl/blob/master/LICENSE.md New BSD License
  */
 
 namespace Laminas\Permissions\Acl\Role;

--- a/src/Role/Registry.php
+++ b/src/Role/Registry.php
@@ -1,15 +1,18 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
- * @copyright https://github.com/laminas/laminas-permissions-acl/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-permissions-acl/blob/master/LICENSE.md New BSD License
  */
 
 namespace Laminas\Permissions\Acl\Role;
 
 use Laminas\Permissions\Acl\Exception;
 use Traversable;
+
+use function is_array;
+use function sprintf;
 
 class Registry
 {
@@ -34,7 +37,6 @@ class Registry
      * will have the least priority, and the last parent added will have the
      * highest priority.
      *
-     * @param  RoleInterface                           $role
      * @param  RoleInterface|string|array|Traversable $parents
      * @throws Exception\InvalidArgumentException
      * @return Registry Provides a fluent interface
@@ -70,7 +72,7 @@ class Registry
                         $roleParentId
                     ), 0, $e);
                 }
-                $roleParents[$roleParentId] = $roleParent;
+                $roleParents[$roleParentId]                      = $roleParent;
                 $this->roles[$roleParentId]['children'][$roleId] = $role;
             }
         }

--- a/src/Role/Registry.php
+++ b/src/Role/Registry.php
@@ -1,10 +1,10 @@
 <?php
 
-declare(strict_types=1);
-
 /**
- * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
+ * @see https://github.com/laminas/laminas-permissions-acl for the canonical source repository
  */
+
+declare(strict_types=1);
 
 namespace Laminas\Permissions\Acl\Role;
 

--- a/src/Role/RoleInterface.php
+++ b/src/Role/RoleInterface.php
@@ -1,10 +1,10 @@
 <?php
 
-declare(strict_types=1);
-
 /**
- * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
+ * @see https://github.com/laminas/laminas-permissions-acl for the canonical source repository
  */
+
+declare(strict_types=1);
 
 namespace Laminas\Permissions\Acl\Role;
 

--- a/src/Role/RoleInterface.php
+++ b/src/Role/RoleInterface.php
@@ -1,9 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
- * @copyright https://github.com/laminas/laminas-permissions-acl/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-permissions-acl/blob/master/LICENSE.md New BSD License
  */
 
 namespace Laminas\Permissions\Acl\Role;

--- a/test/AclTest.php
+++ b/test/AclTest.php
@@ -1,10 +1,10 @@
 <?php
 
-declare(strict_types=1);
-
 /**
- * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
+ * @see https://github.com/laminas/laminas-permissions-acl for the canonical source repository
  */
+
+declare(strict_types=1);
 
 namespace LaminasTest\Permissions\Acl;
 

--- a/test/AclTest.php
+++ b/test/AclTest.php
@@ -1,13 +1,14 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
- * @copyright https://github.com/laminas/laminas-permissions-acl/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-permissions-acl/blob/master/LICENSE.md New BSD License
  */
 
 namespace LaminasTest\Permissions\Acl;
 
+use ArrayIterator;
 use Laminas\Permissions\Acl;
 use Laminas\Permissions\Acl\Exception\ExceptionInterface;
 use Laminas\Permissions\Acl\Exception\InvalidArgumentException;
@@ -27,8 +28,6 @@ class AclTest extends TestCase
 
     /**
      * Instantiates a new ACL object and creates internal reference to it for each test method
-     *
-     * @return void
      */
     protected function setUp(): void
     {
@@ -122,7 +121,7 @@ class AclTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('addRole() expects $role to be of type Laminas\Permissions\Acl\Role');
-        $this->acl->addRole(new \stdClass, 'guest');
+        $this->acl->addRole(new stdClass(), 'guest');
     }
 
     /**
@@ -159,9 +158,9 @@ class AclTest extends TestCase
      */
     public function testRoleRegistryInherits()
     {
-        $roleGuest  = new Role\GenericRole('guest');
-        $roleMember = new Role\GenericRole('member');
-        $roleEditor = new Role\GenericRole('editor');
+        $roleGuest    = new Role\GenericRole('guest');
+        $roleMember   = new Role\GenericRole('member');
+        $roleEditor   = new Role\GenericRole('editor');
         $roleRegistry = new Role\Registry();
         $roleRegistry
             ->add($roleGuest)
@@ -192,9 +191,9 @@ class AclTest extends TestCase
      */
     public function testRoleRegistryInheritsMultipleArray()
     {
-        $roleParent1 = new Role\GenericRole('parent1');
-        $roleParent2 = new Role\GenericRole('parent2');
-        $roleChild   = new Role\GenericRole('child');
+        $roleParent1  = new Role\GenericRole('parent1');
+        $roleParent2  = new Role\GenericRole('parent2');
+        $roleChild    = new Role\GenericRole('child');
         $roleRegistry = new Role\Registry();
         $roleRegistry
             ->add($roleParent1)
@@ -223,16 +222,16 @@ class AclTest extends TestCase
      */
     public function testRoleRegistryInheritsMultipleTraversable()
     {
-        $roleParent1 = new Role\GenericRole('parent1');
-        $roleParent2 = new Role\GenericRole('parent2');
-        $roleChild   = new Role\GenericRole('child');
+        $roleParent1  = new Role\GenericRole('parent1');
+        $roleParent2  = new Role\GenericRole('parent2');
+        $roleChild    = new Role\GenericRole('child');
         $roleRegistry = new Role\Registry();
         $roleRegistry
             ->add($roleParent1)
             ->add($roleParent2)
             ->add(
                 $roleChild,
-                new \ArrayIterator([$roleParent1, $roleParent2])
+                new ArrayIterator([$roleParent1, $roleParent2])
             );
         $roleChildParents = $roleRegistry->getParents($roleChild);
         $this->assertCount(2, $roleChildParents);
@@ -257,7 +256,7 @@ class AclTest extends TestCase
      */
     public function testRoleRegistryDuplicate()
     {
-        $roleGuest = new Role\GenericRole('guest');
+        $roleGuest    = new Role\GenericRole('guest');
         $roleRegistry = new Role\Registry();
         $this->expectException(InvalidArgumentException::class, 'already exists');
         $roleRegistry
@@ -272,8 +271,8 @@ class AclTest extends TestCase
      */
     public function testRoleRegistryDuplicateId()
     {
-        $roleGuest1 = new Role\GenericRole('guest');
-        $roleGuest2 = new Role\GenericRole('guest');
+        $roleGuest1   = new Role\GenericRole('guest');
+        $roleGuest2   = new Role\GenericRole('guest');
         $roleRegistry = new Role\Registry();
         $this->expectException(InvalidArgumentException::class, 'already exists');
         $roleRegistry
@@ -289,7 +288,7 @@ class AclTest extends TestCase
     public function testResourceAddAndGetOne()
     {
         $resourceArea = new Resource\GenericResource('area');
-        $resource = $this->acl
+        $resource     = $this->acl
             ->addResource($resourceArea)
             ->getResource($resourceArea->getResourceId());
         $this->assertEquals($resourceArea, $resource);
@@ -317,7 +316,7 @@ class AclTest extends TestCase
     public function testResourceAddAndGetOneWithAddResourceMethod()
     {
         $resourceArea = new Resource\GenericResource('area');
-        $resource = $this->acl
+        $resource     = $this->acl
             ->addResource($resourceArea)
             ->getResource($resourceArea->getResourceId());
         $this->assertEquals($resourceArea, $resource);
@@ -386,7 +385,7 @@ class AclTest extends TestCase
     {
         $this->expectException(InvalidArgumentException::class);
         $this->expectExceptionMessage('addResource() expects $resource to be of type Laminas\Permissions\Acl\Resource');
-        $this->acl->addResource(new stdClass);
+        $this->acl->addResource(new stdClass());
     }
 
     /**
@@ -1160,7 +1159,7 @@ class AclTest extends TestCase
             ->addRole($someRole);
 
         $nullValue     = null;
-        $nullReference =& $nullValue;
+        $nullReference = &$nullValue;
 
         try {
             $acl->exroleDFSVisitAllPrivileges($someRole, $someResource, $nullReference);
@@ -1191,7 +1190,6 @@ class AclTest extends TestCase
         }
     }
 
-
     /**
      * @group Laminas-1721
      */
@@ -1199,7 +1197,7 @@ class AclTest extends TestCase
     {
         $acl = $this->loadStandardUseCase();
 
-        $user = new Role\GenericRole('publisher');
+        $user     = new Role\GenericRole('publisher');
         $blogPost = new Resource\GenericResource('blogPost');
 
         /**
@@ -1213,7 +1211,6 @@ class AclTest extends TestCase
     }
 
     /**
-     *
      * @group Laminas-1722
      */
     public function testAclAssertionsGetOriginalIsAllowedObjects()
@@ -1231,7 +1228,7 @@ class AclTest extends TestCase
         $assertion = $acl->customAssertion;
 
         $assertion->assertReturnValue = true;
-        $user->role = 'contributor';
+        $user->role                   = 'contributor';
         $this->assertTrue($acl->isAllowed($user, $blogPost, 'modify'), 'Assertion should return true');
         $assertion->assertReturnValue = false;
         $this->assertFalse($acl->isAllowed($user, $blogPost, 'modify'), 'Assertion should return false');
@@ -1250,7 +1247,6 @@ class AclTest extends TestCase
     }
 
     /**
-     *
      * @return TestAsset\StandardUseCase\Acl
      */
     protected function loadStandardUseCase()
@@ -1339,7 +1335,7 @@ class AclTest extends TestCase
         $this->acl->addRole(new Role\GenericRole('editor'), 'staff');
         $this->acl->addRole(new Role\GenericRole('administrator'));
 
-        $expected = ['guest', 'staff','editor','administrator'];
+        $expected = ['guest', 'staff', 'editor', 'administrator'];
         $this->assertEquals($expected, $this->acl->getRoles());
     }
 

--- a/test/Assertion/AssertionAggregateTest.php
+++ b/test/Assertion/AssertionAggregateTest.php
@@ -1,10 +1,10 @@
 <?php
 
-declare(strict_types=1);
-
 /**
- * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
+ * @see https://github.com/laminas/laminas-permissions-acl for the canonical source repository
  */
+
+declare(strict_types=1);
 
 namespace LaminasTest\Permissions\Acl\Assertion;
 

--- a/test/Assertion/AssertionAggregateTest.php
+++ b/test/Assertion/AssertionAggregateTest.php
@@ -1,20 +1,23 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
- * @copyright https://github.com/laminas/laminas-permissions-acl/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-permissions-acl/blob/master/LICENSE.md New BSD License
  */
+
 namespace LaminasTest\Permissions\Acl\Assertion;
 
 use InvalidArgumentException as PHPInvalidArgumentException;
 use Laminas\Permissions\Acl\Acl;
-use LaminasTest\Permissions\Acl\Assertion\TestSubclasses\AssertionAggregate;
+use Laminas\Permissions\Acl\Assertion\AssertionInterface;
+use Laminas\Permissions\Acl\Assertion\AssertionManager;
 use Laminas\Permissions\Acl\Assertion\Exception\InvalidAssertionException;
 use Laminas\Permissions\Acl\Exception\InvalidArgumentException;
 use Laminas\Permissions\Acl\Exception\RuntimeException;
 use Laminas\Permissions\Acl\Resource\GenericResource;
 use Laminas\Permissions\Acl\Role\GenericRole;
+use LaminasTest\Permissions\Acl\Assertion\TestSubclasses\AssertionAggregate;
 use PHPUnit\Framework\TestCase;
 
 class AssertionAggregateTest extends TestCase
@@ -28,7 +31,7 @@ class AssertionAggregateTest extends TestCase
 
     public function testAddAssertion()
     {
-        $assertion = $this->getMockForAbstractClass('\Laminas\Permissions\Acl\Assertion\AssertionInterface');
+        $assertion = $this->getMockForAbstractClass(AssertionInterface::class);
         $this->assertionAggregate->addAssertion($assertion);
 
         $this->assertEquals([$assertion], $this->assertionAggregate->peakAssertions());
@@ -36,7 +39,7 @@ class AssertionAggregateTest extends TestCase
         $aggregate = $this->assertionAggregate->addAssertion('other.assertion');
         $this->assertEquals([
             $assertion,
-            'other.assertion'
+            'other.assertion',
         ], $this->assertionAggregate->peakAssertions());
 
         // test fluent interface
@@ -47,8 +50,8 @@ class AssertionAggregateTest extends TestCase
 
     public function testAddAssertions()
     {
-        $assertions[] = $this->getMockForAbstractClass('\Laminas\Permissions\Acl\Assertion\AssertionInterface');
-        $assertions[] = $this->getMockForAbstractClass('\Laminas\Permissions\Acl\Assertion\AssertionInterface');
+        $assertions[] = $this->getMockForAbstractClass(AssertionInterface::class);
+        $assertions[] = $this->getMockForAbstractClass(AssertionInterface::class);
 
         $aggregate = $this->assertionAggregate->addAssertions($assertions);
 
@@ -96,21 +99,21 @@ class AssertionAggregateTest extends TestCase
     {
         return [
             [
-                AssertionAggregate::MODE_ALL
+                AssertionAggregate::MODE_ALL,
             ],
             [
-                AssertionAggregate::MODE_AT_LEAST_ONE
+                AssertionAggregate::MODE_AT_LEAST_ONE,
             ],
             [
                 'invalid mode',
-                true
-            ]
+                true,
+            ],
         ];
     }
 
     public function testManagerAccessors()
     {
-        $manager = $this->getMockBuilder('Laminas\Permissions\Acl\Assertion\AssertionManager')
+        $manager = $this->getMockBuilder(AssertionManager::class)
                         ->disableOriginalConstructor()
                         ->getMock();
 
@@ -122,25 +125,22 @@ class AssertionAggregateTest extends TestCase
     public function testCallingAssertWillFetchAssertionFromManager()
     {
         $acl = $this->getMockBuilder(Acl::class)
-            ->getMock()
-            ;
+            ->getMock();
 
         $role = $this->getMockBuilder(GenericRole::class)
             ->setConstructorArgs(['test.role'])
-            ->getMock()
-            ;
+            ->getMock();
 
         $resource = $this->getMockBuilder(GenericResource::class)
             ->setConstructorArgs(['test.resource'])
-            ->getMock()
-            ;
+            ->getMock();
 
-        $assertion = $this->getMockForAbstractClass('Laminas\Permissions\Acl\Assertion\AssertionInterface');
+        $assertion = $this->getMockForAbstractClass(AssertionInterface::class);
         $assertion->expects($this->once())
             ->method('assert')
             ->will($this->returnValue(true));
 
-        $manager = $this->getMockBuilder('Laminas\Permissions\Acl\Assertion\AssertionManager')
+        $manager = $this->getMockBuilder(AssertionManager::class)
                         ->disableOriginalConstructor()
                         ->getMock();
 
@@ -158,20 +158,17 @@ class AssertionAggregateTest extends TestCase
     public function testAssertThrowsAnExceptionWhenReferingToNonExistentAssertion()
     {
         $acl = $this->getMockBuilder(Acl::class)
-            ->getMock()
-            ;
+            ->getMock();
 
         $role = $this->getMockBuilder(GenericRole::class)
             ->setConstructorArgs(['test.role'])
-            ->getMock()
-            ;
+            ->getMock();
 
         $resource = $this->getMockBuilder(GenericResource::class)
             ->setConstructorArgs(['test.resource'])
-            ->getMock()
-            ;
+            ->getMock();
 
-        $manager = $this->getMockBuilder('Laminas\Permissions\Acl\Assertion\AssertionManager')
+        $manager = $this->getMockBuilder(AssertionManager::class)
                         ->disableOriginalConstructor()
                         ->getMock();
 
@@ -190,22 +187,19 @@ class AssertionAggregateTest extends TestCase
     public function testAssertWithModeAll()
     {
         $acl = $this->getMockBuilder(Acl::class)
-            ->getMock()
-            ;
+            ->getMock();
 
         $role = $this->getMockBuilder(GenericRole::class)
             ->setConstructorArgs(['test.role'])
-            ->getMock()
-            ;
+            ->getMock();
 
         $resource = $this->getMockBuilder(GenericResource::class)
             ->setConstructorArgs(['test.resource'])
-            ->getMock()
-            ;
+            ->getMock();
 
-        $assertions[] = $this->getMockForAbstractClass('\Laminas\Permissions\Acl\Assertion\AssertionInterface');
-        $assertions[] = $this->getMockForAbstractClass('\Laminas\Permissions\Acl\Assertion\AssertionInterface');
-        $assertions[] = $this->getMockForAbstractClass('\Laminas\Permissions\Acl\Assertion\AssertionInterface');
+        $assertions[] = $this->getMockForAbstractClass(AssertionInterface::class);
+        $assertions[] = $this->getMockForAbstractClass(AssertionInterface::class);
+        $assertions[] = $this->getMockForAbstractClass(AssertionInterface::class);
 
         $assertions[0]->expects($this->once())
             ->method('assert')
@@ -230,22 +224,19 @@ class AssertionAggregateTest extends TestCase
     public function testAssertWithModeAtLeastOne()
     {
         $acl = $this->getMockBuilder(Acl::class)
-            ->getMock()
-            ;
+            ->getMock();
 
         $role = $this->getMockBuilder(GenericRole::class)
             ->setConstructorArgs(['test.role'])
-            ->getMock()
-            ;
+            ->getMock();
 
         $resource = $this->getMockBuilder(GenericResource::class)
             ->setConstructorArgs(['test.resource'])
-            ->getMock()
-            ;
+            ->getMock();
 
-        $assertions[] = $this->getMockForAbstractClass('\Laminas\Permissions\Acl\Assertion\AssertionInterface');
-        $assertions[] = $this->getMockForAbstractClass('\Laminas\Permissions\Acl\Assertion\AssertionInterface');
-        $assertions[] = $this->getMockForAbstractClass('\Laminas\Permissions\Acl\Assertion\AssertionInterface');
+        $assertions[] = $this->getMockForAbstractClass(AssertionInterface::class);
+        $assertions[] = $this->getMockForAbstractClass(AssertionInterface::class);
+        $assertions[] = $this->getMockForAbstractClass(AssertionInterface::class);
 
         $assertions[0]->expects($this->once())
             ->method('assert')
@@ -271,24 +262,21 @@ class AssertionAggregateTest extends TestCase
     public function testDoesNotAssertWithModeAll()
     {
         $acl = $this->getMockBuilder(Acl::class)
-            ->getMock()
-            ;
+            ->getMock();
 
         $role = $this->getMockBuilder(GenericRole::class)
             ->setConstructorArgs(['test.role'])
             ->setMethods(['assert'])
-            ->getMock()
-            ;
+            ->getMock();
 
         $resource = $this->getMockBuilder(GenericResource::class)
             ->setConstructorArgs(['test.resource'])
             ->setMethods(['assert'])
-            ->getMock()
-            ;
+            ->getMock();
 
-        $assertions[] = $this->getMockForAbstractClass('\Laminas\Permissions\Acl\Assertion\AssertionInterface');
-        $assertions[] = $this->getMockForAbstractClass('\Laminas\Permissions\Acl\Assertion\AssertionInterface');
-        $assertions[] = $this->getMockForAbstractClass('\Laminas\Permissions\Acl\Assertion\AssertionInterface');
+        $assertions[] = $this->getMockForAbstractClass(AssertionInterface::class);
+        $assertions[] = $this->getMockForAbstractClass(AssertionInterface::class);
+        $assertions[] = $this->getMockForAbstractClass(AssertionInterface::class);
 
         $assertions[0]->expects($this->once())
             ->method('assert')
@@ -313,24 +301,21 @@ class AssertionAggregateTest extends TestCase
     public function testDoesNotAssertWithModeAtLeastOne()
     {
         $acl = $this->getMockBuilder(Acl::class)
-            ->getMock()
-            ;
+            ->getMock();
 
         $role = $this->getMockBuilder(GenericRole::class)
             ->setConstructorArgs(['test.role'])
             ->setMethods(['assert'])
-            ->getMock()
-            ;
+            ->getMock();
 
         $resource = $this->getMockBuilder(GenericResource::class)
             ->setConstructorArgs(['test.resource'])
             ->setMethods(['assert'])
-            ->getMock()
-            ;
+            ->getMock();
 
-        $assertions[] = $this->getMockForAbstractClass('\Laminas\Permissions\Acl\Assertion\AssertionInterface');
-        $assertions[] = $this->getMockForAbstractClass('\Laminas\Permissions\Acl\Assertion\AssertionInterface');
-        $assertions[] = $this->getMockForAbstractClass('\Laminas\Permissions\Acl\Assertion\AssertionInterface');
+        $assertions[] = $this->getMockForAbstractClass(AssertionInterface::class);
+        $assertions[] = $this->getMockForAbstractClass(AssertionInterface::class);
+        $assertions[] = $this->getMockForAbstractClass(AssertionInterface::class);
 
         $assertions[0]->expects($this->once())
             ->method('assert')
@@ -356,20 +341,17 @@ class AssertionAggregateTest extends TestCase
     public function testAssertThrowsAnExceptionWhenNoAssertionIsAggregated()
     {
         $acl = $this->getMockBuilder(Acl::class)
-            ->getMock()
-            ;
+            ->getMock();
 
         $role = $this->getMockBuilder(GenericRole::class)
             ->setConstructorArgs(['test.role'])
             ->setMethods(['assert'])
-            ->getMock()
-            ;
+            ->getMock();
 
         $resource = $this->getMockBuilder(GenericResource::class)
             ->setConstructorArgs(['test.resource'])
             ->setMethods(['assert'])
-            ->getMock()
-            ;
+            ->getMock();
 
         $this->expectException(RuntimeException::class);
 

--- a/test/Assertion/AssertionAggregateTest.php
+++ b/test/Assertion/AssertionAggregateTest.php
@@ -22,14 +22,14 @@ use PHPUnit\Framework\TestCase;
 
 class AssertionAggregateTest extends TestCase
 {
-    protected $assertionAggregate;
+    protected AssertionAggregate $assertionAggregate;
 
     protected function setUp(): void
     {
         $this->assertionAggregate = new AssertionAggregate();
     }
 
-    public function testAddAssertion()
+    public function testAddAssertion(): AssertionAggregate
     {
         $assertion = $this->getMockForAbstractClass(AssertionInterface::class);
         $this->assertionAggregate->addAssertion($assertion);
@@ -84,7 +84,7 @@ class AssertionAggregateTest extends TestCase
     /**
      * @dataProvider getDataForTestSetMode
      */
-    public function testSetMode($mode, $exception = false)
+    public function testSetMode(string $mode, bool $exception = false)
     {
         if ($exception) {
             $this->expectException(InvalidArgumentException::class);
@@ -95,7 +95,7 @@ class AssertionAggregateTest extends TestCase
         }
     }
 
-    public static function getDataForTestSetMode()
+    public static function getDataForTestSetMode(): array
     {
         return [
             [

--- a/test/Assertion/AssertionManagerCompatibilityTest.php
+++ b/test/Assertion/AssertionManagerCompatibilityTest.php
@@ -19,22 +19,26 @@ class AssertionManagerCompatibilityTest extends TestCase
 {
     use CommonPluginManagerTrait;
 
+    // This method deprecated at PHPUnit 5.*, removed at 6.*.
+    // This code does nothing actually but shows errors by phpcs.
+    // phpcs:disable
     public function setExpectedException($exception, $message = '', $code = null)
     {
         $this->expectException($exception, $message, $code);
     }
+    // phpcs:enable
 
-    protected function getPluginManager()
+    protected function getPluginManager(): AssertionManager
     {
         return new AssertionManager(new ServiceManager());
     }
 
-    protected function getV2InvalidPluginException()
+    protected function getV2InvalidPluginException(): string
     {
         return InvalidArgumentException::class;
     }
 
-    protected function getInstanceOf()
+    protected function getInstanceOf(): string
     {
         return AssertionInterface::class;
     }

--- a/test/Assertion/AssertionManagerCompatibilityTest.php
+++ b/test/Assertion/AssertionManagerCompatibilityTest.php
@@ -1,10 +1,10 @@
 <?php
 
-declare(strict_types=1);
-
 /**
- * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
+ * @see https://github.com/laminas/laminas-permissions-acl for the canonical source repository
  */
+
+declare(strict_types=1);
 
 namespace LaminasTest\Permissions\Acl\Assertion;
 

--- a/test/Assertion/AssertionManagerCompatibilityTest.php
+++ b/test/Assertion/AssertionManagerCompatibilityTest.php
@@ -1,10 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
- * @copyright https://github.com/laminas/laminas-permissions-acl/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-permissions-acl/blob/master/LICENSE.md New BSD License
  */
+
 namespace LaminasTest\Permissions\Acl\Assertion;
 
 use Laminas\Permissions\Acl\Assertion\AssertionInterface;

--- a/test/Assertion/AssertionManagerTest.php
+++ b/test/Assertion/AssertionManagerTest.php
@@ -16,7 +16,7 @@ use PHPUnit\Framework\TestCase;
 
 class AssertionManagerTest extends TestCase
 {
-    protected $manager;
+    protected AssertionManager $manager;
 
     protected function setUp(): void
     {

--- a/test/Assertion/AssertionManagerTest.php
+++ b/test/Assertion/AssertionManagerTest.php
@@ -1,10 +1,10 @@
 <?php
 
-declare(strict_types=1);
-
 /**
- * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
+ * @see https://github.com/laminas/laminas-permissions-acl for the canonical source repository
  */
+
+declare(strict_types=1);
 
 namespace LaminasTest\Permissions\Acl\Assertion;
 

--- a/test/Assertion/AssertionManagerTest.php
+++ b/test/Assertion/AssertionManagerTest.php
@@ -1,10 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
- * @copyright https://github.com/laminas/laminas-permissions-acl/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-permissions-acl/blob/master/LICENSE.md New BSD License
  */
+
 namespace LaminasTest\Permissions\Acl\Assertion;
 
 use Laminas\Permissions\Acl\Assertion\AssertionInterface;
@@ -19,7 +20,7 @@ class AssertionManagerTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->manager = new AssertionManager(new ServiceManager);
+        $this->manager = new AssertionManager(new ServiceManager());
     }
 
     public function testValidatePlugin()

--- a/test/Assertion/CallbackAssertionTest.php
+++ b/test/Assertion/CallbackAssertionTest.php
@@ -1,10 +1,10 @@
 <?php
 
-declare(strict_types=1);
-
 /**
- * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
+ * @see https://github.com/laminas/laminas-permissions-acl for the canonical source repository
  */
+
+declare(strict_types=1);
 
 namespace LaminasTest\Permissions\Acl\Assertion;
 

--- a/test/Assertion/CallbackAssertionTest.php
+++ b/test/Assertion/CallbackAssertionTest.php
@@ -1,14 +1,17 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
- * @copyright https://github.com/laminas/laminas-permissions-acl/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-permissions-acl/blob/master/LICENSE.md New BSD License
  */
+
 namespace LaminasTest\Permissions\Acl\Assertion;
 
 use Laminas\Permissions\Acl;
 use Laminas\Permissions\Acl\Exception\InvalidArgumentException;
+use Laminas\Permissions\Acl\Resource\ResourceInterface;
+use Laminas\Permissions\Acl\Role\RoleInterface;
 use LaminasTest\Permissions\Acl\Assertion\TestSubclasses\CallbackAssertion;
 use PHPUnit\Framework\TestCase;
 
@@ -31,9 +34,9 @@ class CallbackAssertionTest extends TestCase
      */
     public function testCallbackIsSet()
     {
-        $callback   = function () {
+        $callback = function () {
         };
-        $assert     = new CallbackAssertion($callback);
+        $assert   = new CallbackAssertion($callback);
         $this->assertSame($callback, $assert->peakCallback());
     }
 
@@ -42,14 +45,14 @@ class CallbackAssertionTest extends TestCase
      */
     public function testAssertMethodPassArgsToCallback()
     {
-        $acl       = new Acl\Acl();
-        $that      = $this;
-        $assert    = new CallbackAssertion(
+        $acl    = new Acl\Acl();
+        $that   = $this;
+        $assert = new CallbackAssertion(
             function ($aclArg, $roleArg, $resourceArg, $privilegeArg) use ($that, $acl) {
                 $that->assertSame($acl, $aclArg);
-                $that->assertInstanceOf('Laminas\Permissions\Acl\Role\RoleInterface', $roleArg);
+                $that->assertInstanceOf(RoleInterface::class, $roleArg);
                 $that->assertEquals('guest', $roleArg->getRoleId());
-                $that->assertInstanceOf('Laminas\Permissions\Acl\Resource\ResourceInterface', $resourceArg);
+                $that->assertInstanceOf(ResourceInterface::class, $resourceArg);
                 $that->assertEquals('area1', $resourceArg->getResourceId());
                 $that->assertEquals('somePrivilege', $privilegeArg);
                 return false;
@@ -67,8 +70,8 @@ class CallbackAssertionTest extends TestCase
      */
     public function testAssertMethod()
     {
-        $acl       = new Acl\Acl();
-        $roleGuest = new Acl\Role\GenericRole('guest');
+        $acl        = new Acl\Acl();
+        $roleGuest  = new Acl\Role\GenericRole('guest');
         $assertMock = function ($value) {
             return function ($aclArg, $roleArg, $resourceArg, $privilegeArg) use ($value) {
                 return $value;

--- a/test/Assertion/ExpressionAssertionTest.php
+++ b/test/Assertion/ExpressionAssertionTest.php
@@ -77,8 +77,13 @@ class ExpressionAssertionTest extends TestCase
     /**
      * @dataProvider getExpressions
      */
-    public function testExpressionsEvaluation(array $expression, $role, $resource, $privilege, $expectedAssert)
-    {
+    public function testExpressionsEvaluation(
+        array $expression,
+        User $role,
+        BlogPost $resource,
+        string $privilege,
+        bool $expectedAssert
+    ) {
         $assertion = ExpressionAssertion::fromArray($expression);
 
         $this->assertThat(
@@ -87,7 +92,7 @@ class ExpressionAssertionTest extends TestCase
         );
     }
 
-    public function getExpressions()
+    public function getExpressions(): array
     {
         $author3 = new User([
             'username' => 'author3',

--- a/test/Assertion/ExpressionAssertionTest.php
+++ b/test/Assertion/ExpressionAssertionTest.php
@@ -1,10 +1,10 @@
 <?php
 
-declare(strict_types=1);
-
 /**
- * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
+ * @see https://github.com/laminas/laminas-permissions-acl for the canonical source repository
  */
+
+declare(strict_types=1);
 
 namespace LaminasTest\Permissions\Acl\Assertion;
 

--- a/test/Assertion/ExpressionAssertionTest.php
+++ b/test/Assertion/ExpressionAssertionTest.php
@@ -1,9 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
- * @copyright https://github.com/laminas/laminas-permissions-acl/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-permissions-acl/blob/master/LICENSE.md New BSD License
  */
 
 namespace LaminasTest\Permissions\Acl\Assertion;
@@ -15,6 +15,8 @@ use Laminas\Permissions\Acl\Exception\RuntimeException;
 use LaminasTest\Permissions\Acl\TestAsset\ExpressionUseCase\BlogPost;
 use LaminasTest\Permissions\Acl\TestAsset\ExpressionUseCase\User;
 use PHPUnit\Framework\TestCase;
+
+use function serialize;
 
 class ExpressionAssertionTest extends TestCase
 {
@@ -32,9 +34,9 @@ class ExpressionAssertionTest extends TestCase
     public function testFromArrayCreation()
     {
         $assertion = ExpressionAssertion::fromArray([
-            'left' => 'foo',
+            'left'     => 'foo',
             'operator' => ExpressionAssertion::OPERATOR_EQ,
-            'right' => 'bar'
+            'right'    => 'bar',
         ]);
 
         $this->assertInstanceOf(ExpressionAssertion::class, $assertion);
@@ -90,225 +92,225 @@ class ExpressionAssertionTest extends TestCase
         $author3 = new User([
             'username' => 'author3',
         ]);
-        $post3 = new BlogPost([
+        $post3   = new BlogPost([
             'author' => $author3,
         ]);
 
         return [
-            'equality' => [
+            'equality'                     => [
                 'expression' => [
-                    'left' => [ExpressionAssertion::OPERAND_CONTEXT_PROPERTY => 'role.username'],
+                    'left'     => [ExpressionAssertion::OPERAND_CONTEXT_PROPERTY => 'role.username'],
                     'operator' => ExpressionAssertion::OPERATOR_EQ,
-                    'right' => 'test',
+                    'right'    => 'test',
                 ],
-                'role' => new User([
+                'role'       => new User([
                     'username' => 'test',
                 ]),
-                'resource' => new BlogPost(),
-                'privilege' => 'read',
-                'assert' => true,
+                'resource'   => new BlogPost(),
+                'privilege'  => 'read',
+                'assert'     => true,
             ],
-            'inequality' => [
+            'inequality'                   => [
                 'expression' => [
-                    'left' => [ExpressionAssertion::OPERAND_CONTEXT_PROPERTY => 'role.username'],
+                    'left'     => [ExpressionAssertion::OPERAND_CONTEXT_PROPERTY => 'role.username'],
                     'operator' => ExpressionAssertion::OPERATOR_NEQ,
-                    'right' => 'test',
+                    'right'    => 'test',
                 ],
-                'role' => new User([
+                'role'       => new User([
                     'username' => 'foobar',
                 ]),
-                'resource' => new BlogPost(),
-                'privilege' => 'read',
-                'assert' => true,
+                'resource'   => new BlogPost(),
+                'privilege'  => 'read',
+                'assert'     => true,
             ],
-            'boolean-equality' => [
+            'boolean-equality'             => [
                 'expression' => [
-                    'left' => [ExpressionAssertion::OPERAND_CONTEXT_PROPERTY => 'role.username'],
+                    'left'     => [ExpressionAssertion::OPERAND_CONTEXT_PROPERTY => 'role.username'],
                     'operator' => ExpressionAssertion::OPERATOR_EQ,
-                    'right' => true,
+                    'right'    => true,
                 ],
-                'role' => $author3,
-                'resource' => $post3,
-                'privilege' => 'read',
-                'assert' => true,
+                'role'       => $author3,
+                'resource'   => $post3,
+                'privilege'  => 'read',
+                'assert'     => true,
             ],
-            'greater-than' => [
+            'greater-than'                 => [
                 'expression' => [
-                    'left' => [ExpressionAssertion::OPERAND_CONTEXT_PROPERTY => 'role.age'],
+                    'left'     => [ExpressionAssertion::OPERAND_CONTEXT_PROPERTY => 'role.age'],
                     'operator' => ExpressionAssertion::OPERATOR_GT,
-                    'right' => 20,
+                    'right'    => 20,
                 ],
-                'role' => new User([
+                'role'       => new User([
                     'username' => 'foobar',
-                    'age' => 15,
+                    'age'      => 15,
                 ]),
-                'resource' => new BlogPost(),
-                'privilege' => 'read',
-                'assert' => false,
+                'resource'   => new BlogPost(),
+                'privilege'  => 'read',
+                'assert'     => false,
             ],
-            'greater-than-or-equal' => [
+            'greater-than-or-equal'        => [
                 'expression' => [
-                    'left' => [ExpressionAssertion::OPERAND_CONTEXT_PROPERTY => 'role.age'],
+                    'left'     => [ExpressionAssertion::OPERAND_CONTEXT_PROPERTY => 'role.age'],
                     'operator' => ExpressionAssertion::OPERATOR_GTE,
-                    'right' => 20,
+                    'right'    => 20,
                 ],
-                'role' => new User([
+                'role'       => new User([
                     'username' => 'foobar',
-                    'age' => 20,
+                    'age'      => 20,
                 ]),
-                'resource' => new BlogPost(),
-                'privilege' => 'read',
-                'assert' => true,
+                'resource'   => new BlogPost(),
+                'privilege'  => 'read',
+                'assert'     => true,
             ],
-            'less-than' => [
+            'less-than'                    => [
                 'expression' => [
-                    'left' => [ExpressionAssertion::OPERAND_CONTEXT_PROPERTY => 'role.age'],
+                    'left'     => [ExpressionAssertion::OPERAND_CONTEXT_PROPERTY => 'role.age'],
                     'operator' => ExpressionAssertion::OPERATOR_LT,
-                    'right' => 30,
+                    'right'    => 30,
                 ],
-                'role' => new User([
+                'role'       => new User([
                     'username' => 'foobar',
-                    'age' => 20,
+                    'age'      => 20,
                 ]),
-                'resource' => new BlogPost(),
-                'privilege' => 'read',
-                'assert' => true,
+                'resource'   => new BlogPost(),
+                'privilege'  => 'read',
+                'assert'     => true,
             ],
-            'less-than-or-equal' => [
+            'less-than-or-equal'           => [
                 'expression' => [
-                    'left' => [ExpressionAssertion::OPERAND_CONTEXT_PROPERTY => 'role.age'],
+                    'left'     => [ExpressionAssertion::OPERAND_CONTEXT_PROPERTY => 'role.age'],
                     'operator' => ExpressionAssertion::OPERATOR_LTE,
-                    'right' => 30,
+                    'right'    => 30,
                 ],
-                'role' => new User([
+                'role'       => new User([
                     'username' => 'foobar',
-                    'age' => 30,
+                    'age'      => 30,
                 ]),
-                'resource' => new BlogPost(),
-                'privilege' => 'read',
-                'assert' => true,
+                'resource'   => new BlogPost(),
+                'privilege'  => 'read',
+                'assert'     => true,
             ],
-            'in' => [
+            'in'                           => [
                 'expression' => [
-                    'left' => [ExpressionAssertion::OPERAND_CONTEXT_PROPERTY => 'role.username'],
+                    'left'     => [ExpressionAssertion::OPERAND_CONTEXT_PROPERTY => 'role.username'],
                     'operator' => ExpressionAssertion::OPERATOR_IN,
-                    'right' => ['foo', 'bar'],
+                    'right'    => ['foo', 'bar'],
                 ],
-                'role' => new User([
+                'role'       => new User([
                     'username' => 'test',
                 ]),
-                'resource' => new BlogPost(),
-                'privilege' => 'read',
-                'assert' => false,
+                'resource'   => new BlogPost(),
+                'privilege'  => 'read',
+                'assert'     => false,
             ],
-            'not-in' => [
+            'not-in'                       => [
                 'expression' => [
-                    'left' => [ExpressionAssertion::OPERAND_CONTEXT_PROPERTY => 'role.username'],
+                    'left'     => [ExpressionAssertion::OPERAND_CONTEXT_PROPERTY => 'role.username'],
                     'operator' => ExpressionAssertion::OPERATOR_NIN,
-                    'right' => ['foo', 'bar'],
+                    'right'    => ['foo', 'bar'],
                 ],
-                'role' => new User([
+                'role'       => new User([
                     'username' => 'test',
                 ]),
-                'resource' => new BlogPost(),
-                'privilege' => 'read',
-                'assert' => true,
+                'resource'   => new BlogPost(),
+                'privilege'  => 'read',
+                'assert'     => true,
             ],
-            'regex' => [
+            'regex'                        => [
                 'expression' => [
-                    'left' => [ExpressionAssertion::OPERAND_CONTEXT_PROPERTY => 'role.username'],
+                    'left'     => [ExpressionAssertion::OPERAND_CONTEXT_PROPERTY => 'role.username'],
                     'operator' => ExpressionAssertion::OPERATOR_REGEX,
-                    'right' => '/foobar/',
+                    'right'    => '/foobar/',
                 ],
-                'role' => new User([
+                'role'       => new User([
                     'username' => 'test',
                 ]),
-                'resource' => new BlogPost(),
-                'privilege' => 'read',
-                'assert' => false,
+                'resource'   => new BlogPost(),
+                'privilege'  => 'read',
+                'assert'     => false,
             ],
-            'REGEX' => [
+            'REGEX'                        => [
                 'expression' => [
-                    'left' => [ExpressionAssertion::OPERAND_CONTEXT_PROPERTY => 'resource.shortDescription'],
+                    'left'     => [ExpressionAssertion::OPERAND_CONTEXT_PROPERTY => 'resource.shortDescription'],
                     'operator' => 'REGEX',
-                    'right' => '/ipsum/',
+                    'right'    => '/ipsum/',
                 ],
-                'role' => new User([
+                'role'       => new User([
                     'username' => 'test',
                 ]),
-                'resource' => new BlogPost([
-                    'title' => 'Test',
-                    'content' => 'lorem ipsum dolor sit amet',
-                    'shortDescription' => 'lorem ipsum'
+                'resource'   => new BlogPost([
+                    'title'            => 'Test',
+                    'content'          => 'lorem ipsum dolor sit amet',
+                    'shortDescription' => 'lorem ipsum',
                 ]),
-                'privilege' => 'read',
-                'assert' => true,
+                'privilege'  => 'read',
+                'assert'     => true,
             ],
-            'nregex' => [
+            'nregex'                       => [
                 'expression' => [
-                    'left' => [ExpressionAssertion::OPERAND_CONTEXT_PROPERTY => 'role.username'],
+                    'left'     => [ExpressionAssertion::OPERAND_CONTEXT_PROPERTY => 'role.username'],
                     'operator' => ExpressionAssertion::OPERATOR_NREGEX,
-                    'right' => '/barbaz/',
+                    'right'    => '/barbaz/',
                 ],
-                'role' => new User([
+                'role'       => new User([
                     'username' => 'test',
                 ]),
-                'resource' => new BlogPost(),
-                'privilege' => 'read',
-                'assert' => true,
+                'resource'   => new BlogPost(),
+                'privilege'  => 'read',
+                'assert'     => true,
             ],
-            'same' => [
+            'same'                         => [
                 'expression' => [
-                    'left' => [ExpressionAssertion::OPERAND_CONTEXT_PROPERTY => 'role.username'],
+                    'left'     => [ExpressionAssertion::OPERAND_CONTEXT_PROPERTY => 'role.username'],
                     'operator' => ExpressionAssertion::OPERATOR_SAME,
-                    'right' => 'test',
+                    'right'    => 'test',
                 ],
-                'role' => new User([
+                'role'       => new User([
                     'username' => 'test',
                 ]),
-                'resource' => new BlogPost(),
-                'privilege' => 'read',
-                'assert' => true,
+                'resource'   => new BlogPost(),
+                'privilege'  => 'read',
+                'assert'     => true,
             ],
-            'not-same' => [
+            'not-same'                     => [
                 'expression' => [
-                    'left' => [ExpressionAssertion::OPERAND_CONTEXT_PROPERTY => 'role.username'],
+                    'left'     => [ExpressionAssertion::OPERAND_CONTEXT_PROPERTY => 'role.username'],
                     'operator' => ExpressionAssertion::OPERATOR_NSAME,
-                    'right' => 'test',
+                    'right'    => 'test',
                 ],
-                'role' => new User([
+                'role'       => new User([
                     'username' => 'foobar',
                 ]),
-                'resource' => new BlogPost(),
-                'privilege' => 'read',
-                'assert' => true,
+                'resource'   => new BlogPost(),
+                'privilege'  => 'read',
+                'assert'     => true,
             ],
             'equality-calculated-property' => [
                 'expression' => [
-                    'left' => [ExpressionAssertion::OPERAND_CONTEXT_PROPERTY => 'role.adult'],
+                    'left'     => [ExpressionAssertion::OPERAND_CONTEXT_PROPERTY => 'role.adult'],
                     'operator' => ExpressionAssertion::OPERATOR_EQ,
-                    'right' => true,
+                    'right'    => true,
                 ],
-                'role' => new User([
+                'role'       => new User([
                     'username' => 'test',
-                    'age' => 30,
+                    'age'      => 30,
                 ]),
-                'resource' => new BlogPost(),
-                'privilege' => 'read',
-                'assert' => true,
+                'resource'   => new BlogPost(),
+                'privilege'  => 'read',
+                'assert'     => true,
             ],
-            'privilege' => [
+            'privilege'                    => [
                 'expression' => [
-                    'left' => [ExpressionAssertion::OPERAND_CONTEXT_PROPERTY => 'privilege'],
+                    'left'     => [ExpressionAssertion::OPERAND_CONTEXT_PROPERTY => 'privilege'],
                     'operator' => ExpressionAssertion::OPERATOR_EQ,
-                    'right' => 'read',
+                    'right'    => 'read',
                 ],
-                'role' => new User([
+                'role'       => new User([
                     'username' => 'test',
                 ]),
-                'resource' => new BlogPost(),
-                'privilege' => 'update',
-                'assert' => false,
+                'resource'   => new BlogPost(),
+                'privilege'  => 'update',
+                'assert'     => false,
             ],
         ];
     }

--- a/test/Assertion/OwnershipAssertionTest.php
+++ b/test/Assertion/OwnershipAssertionTest.php
@@ -1,9 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
- * @copyright https://github.com/laminas/laminas-permissions-acl/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-permissions-acl/blob/master/LICENSE.md New BSD License
  */
 
 namespace LaminasTest\Permissions\Acl\Assertion;
@@ -37,7 +37,7 @@ class OwnershipAssertionTest extends TestCase
 
         $author = new OwnershipUseCase\Author1();
 
-        $blogPost = new OwnershipUseCase\BlogPost();
+        $blogPost         = new OwnershipUseCase\BlogPost();
         $blogPost->author = null;
 
         $this->assertTrue($acl->isAllowed($author, 'blogPost', 'write'));
@@ -51,7 +51,7 @@ class OwnershipAssertionTest extends TestCase
         $author1 = new OwnershipUseCase\Author1();
         $author2 = new OwnershipUseCase\Author2();
 
-        $blogPost = new OwnershipUseCase\BlogPost();
+        $blogPost         = new OwnershipUseCase\BlogPost();
         $blogPost->author = $author1;
 
         $this->assertTrue($acl->isAllowed($author2, 'blogPost', 'write'));

--- a/test/Assertion/OwnershipAssertionTest.php
+++ b/test/Assertion/OwnershipAssertionTest.php
@@ -1,10 +1,10 @@
 <?php
 
-declare(strict_types=1);
-
 /**
- * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
+ * @see https://github.com/laminas/laminas-permissions-acl for the canonical source repository
  */
+
+declare(strict_types=1);
 
 namespace LaminasTest\Permissions\Acl\Assertion;
 

--- a/test/Assertion/TestSubclasses/AssertionAggregate.php
+++ b/test/Assertion/TestSubclasses/AssertionAggregate.php
@@ -1,10 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
- * @copyright https://github.com/laminas/laminas-permissions-acl/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-permissions-acl/blob/master/LICENSE.md New BSD License
  */
+
 namespace LaminasTest\Permissions\Acl\Assertion\TestSubclasses;
 
 final class AssertionAggregate extends \Laminas\Permissions\Acl\Assertion\AssertionAggregate

--- a/test/Assertion/TestSubclasses/AssertionAggregate.php
+++ b/test/Assertion/TestSubclasses/AssertionAggregate.php
@@ -1,10 +1,10 @@
 <?php
 
-declare(strict_types=1);
-
 /**
- * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
+ * @see https://github.com/laminas/laminas-permissions-acl for the canonical source repository
  */
+
+declare(strict_types=1);
 
 namespace LaminasTest\Permissions\Acl\Assertion\TestSubclasses;
 

--- a/test/Assertion/TestSubclasses/CallbackAssertion.php
+++ b/test/Assertion/TestSubclasses/CallbackAssertion.php
@@ -1,10 +1,10 @@
 <?php
 
-declare(strict_types=1);
-
 /**
- * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
+ * @see https://github.com/laminas/laminas-permissions-acl for the canonical source repository
  */
+
+declare(strict_types=1);
 
 namespace LaminasTest\Permissions\Acl\Assertion\TestSubclasses;
 

--- a/test/Assertion/TestSubclasses/CallbackAssertion.php
+++ b/test/Assertion/TestSubclasses/CallbackAssertion.php
@@ -1,10 +1,11 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
- * @copyright https://github.com/laminas/laminas-permissions-acl/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-permissions-acl/blob/master/LICENSE.md New BSD License
  */
+
 namespace LaminasTest\Permissions\Acl\Assertion\TestSubclasses;
 
 final class CallbackAssertion extends \Laminas\Permissions\Acl\Assertion\CallbackAssertion

--- a/test/TestAsset/AssertionLaminas7973.php
+++ b/test/TestAsset/AssertionLaminas7973.php
@@ -1,9 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
- * @copyright https://github.com/laminas/laminas-permissions-acl/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-permissions-acl/blob/master/LICENSE.md New BSD License
  */
 
 namespace LaminasTest\Permissions\Acl\TestAsset;
@@ -15,8 +15,8 @@ class AssertionLaminas7973 implements AssertionInterface
 {
     public function assert(
         Acl\Acl $acl,
-        Acl\Role\RoleInterface $role = null,
-        Acl\Resource\ResourceInterface $resource = null,
+        ?Acl\Role\RoleInterface $role = null,
+        ?Acl\Resource\ResourceInterface $resource = null,
         $privilege = null
     ) {
         if ($privilege != 'privilege') {

--- a/test/TestAsset/AssertionLaminas7973.php
+++ b/test/TestAsset/AssertionLaminas7973.php
@@ -13,13 +13,16 @@ use Laminas\Permissions\Acl\Assertion\AssertionInterface;
 
 class AssertionLaminas7973 implements AssertionInterface
 {
+    /**
+     * @param  mixed|null  $privilege
+     */
     public function assert(
         Acl\Acl $acl,
         ?Acl\Role\RoleInterface $role = null,
         ?Acl\Resource\ResourceInterface $resource = null,
-        $privilege = null
-    ) {
-        if ($privilege != 'privilege') {
+        ?string $privilege = null
+    ): bool {
+        if ($privilege !== 'privilege') {
             return false;
         }
 

--- a/test/TestAsset/AssertionLaminas7973.php
+++ b/test/TestAsset/AssertionLaminas7973.php
@@ -1,10 +1,10 @@
 <?php
 
-declare(strict_types=1);
-
 /**
- * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
+ * @see https://github.com/laminas/laminas-permissions-acl for the canonical source repository
  */
+
+declare(strict_types=1);
 
 namespace LaminasTest\Permissions\Acl\TestAsset;
 

--- a/test/TestAsset/ChildBooleanAssertion.php
+++ b/test/TestAsset/ChildBooleanAssertion.php
@@ -18,16 +18,19 @@ use Laminas\Permissions\Acl\Role\RoleInterface;
  */
 class ChildBooleanAssertion implements AssertionInterface
 {
-    /** @var bool */
-    private $value;
+    private bool $value;
 
-    public function __construct($value)
+    public function __construct(bool $value)
     {
-        $this->value = (bool) $value;
+        $this->value = $value;
     }
 
-    public function assert(Acl $acl, ?RoleInterface $role = null, ?ResourceInterface $resource = null, $privilege = null)
-    {
+    public function assert(
+        Acl $acl,
+        ?RoleInterface $role = null,
+        ?ResourceInterface $resource = null,
+        ?string $privilege = null
+    ): bool {
         return $this->value;
     }
 }

--- a/test/TestAsset/ChildBooleanAssertion.php
+++ b/test/TestAsset/ChildBooleanAssertion.php
@@ -1,10 +1,10 @@
 <?php
 
-declare(strict_types=1);
-
 /**
- * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
+ * @see https://github.com/laminas/laminas-permissions-acl for the canonical source repository
  */
+
+declare(strict_types=1);
 
 namespace LaminasTest\Permissions\Acl\TestAsset;
 

--- a/test/TestAsset/ChildBooleanAssertion.php
+++ b/test/TestAsset/ChildBooleanAssertion.php
@@ -1,9 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
- * @copyright https://github.com/laminas/laminas-permissions-acl/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-permissions-acl/blob/master/LICENSE.md New BSD License
  */
 
 namespace LaminasTest\Permissions\Acl\TestAsset;
@@ -26,7 +26,7 @@ class ChildBooleanAssertion implements AssertionInterface
         $this->value = (bool) $value;
     }
 
-    public function assert(Acl $acl, RoleInterface $role = null, ResourceInterface $resource = null, $privilege = null)
+    public function assert(Acl $acl, ?RoleInterface $role = null, ?ResourceInterface $resource = null, $privilege = null)
     {
         return $this->value;
     }

--- a/test/TestAsset/ExpressionUseCase/BlogPost.php
+++ b/test/TestAsset/ExpressionUseCase/BlogPost.php
@@ -1,10 +1,10 @@
 <?php
 
-declare(strict_types=1);
-
 /**
- * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
+ * @see https://github.com/laminas/laminas-permissions-acl for the canonical source repository
  */
+
+declare(strict_types=1);
 
 namespace LaminasTest\Permissions\Acl\TestAsset\ExpressionUseCase;
 

--- a/test/TestAsset/ExpressionUseCase/BlogPost.php
+++ b/test/TestAsset/ExpressionUseCase/BlogPost.php
@@ -12,12 +12,16 @@ use Laminas\Permissions\Acl\Resource\ResourceInterface;
 
 class BlogPost implements ResourceInterface
 {
+    /** @var mixed */
     public $title;
 
+    /** @var mixed */
     public $shortDescription;
 
+    /** @var mixed */
     public $content;
 
+    /** @var mixed */
     public $author;
 
     public function __construct(array $data = [])
@@ -27,17 +31,20 @@ class BlogPost implements ResourceInterface
         }
     }
 
-    public function getResourceId()
+    public function getResourceId(): string
     {
         return 'blogPost';
     }
 
+    /**
+     * @return mixed
+     */
     public function getShortDescription()
     {
         return $this->shortDescription;
     }
 
-    public function getAuthorName()
+    public function getAuthorName(): string
     {
         return $this->author ? $this->author->username : '';
     }

--- a/test/TestAsset/ExpressionUseCase/BlogPost.php
+++ b/test/TestAsset/ExpressionUseCase/BlogPost.php
@@ -1,9 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
- * @copyright https://github.com/laminas/laminas-permissions-acl/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-permissions-acl/blob/master/LICENSE.md New BSD License
  */
 
 namespace LaminasTest\Permissions\Acl\TestAsset\ExpressionUseCase;

--- a/test/TestAsset/ExpressionUseCase/User.php
+++ b/test/TestAsset/ExpressionUseCase/User.php
@@ -1,10 +1,10 @@
 <?php
 
-declare(strict_types=1);
-
 /**
- * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
+ * @see https://github.com/laminas/laminas-permissions-acl for the canonical source repository
  */
+
+declare(strict_types=1);
 
 namespace LaminasTest\Permissions\Acl\TestAsset\ExpressionUseCase;
 

--- a/test/TestAsset/ExpressionUseCase/User.php
+++ b/test/TestAsset/ExpressionUseCase/User.php
@@ -12,10 +12,12 @@ use Laminas\Permissions\Acl\Role\RoleInterface;
 
 class User implements RoleInterface
 {
+    /** @var mixed */
     public $username;
 
-    public $role = 'guest';
+    public string $role = 'guest';
 
+    /** @var mixed */
     public $age;
 
     public function __construct(array $data = [])
@@ -25,12 +27,12 @@ class User implements RoleInterface
         }
     }
 
-    public function getRoleId()
+    public function getRoleId(): string
     {
         return $this->role;
     }
 
-    public function isAdult()
+    public function isAdult(): bool
     {
         return $this->age >= 18;
     }

--- a/test/TestAsset/ExpressionUseCase/User.php
+++ b/test/TestAsset/ExpressionUseCase/User.php
@@ -1,9 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
- * @copyright https://github.com/laminas/laminas-permissions-acl/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-permissions-acl/blob/master/LICENSE.md New BSD License
  */
 
 namespace LaminasTest\Permissions\Acl\TestAsset\ExpressionUseCase;

--- a/test/TestAsset/ExtendedAclLaminas2234.php
+++ b/test/TestAsset/ExtendedAclLaminas2234.php
@@ -1,9 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
- * @copyright https://github.com/laminas/laminas-permissions-acl/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-permissions-acl/blob/master/LICENSE.md New BSD License
  */
 
 namespace LaminasTest\Permissions\Acl\TestAsset;
@@ -14,29 +14,26 @@ class ExtendedAclLaminas2234 extends Acl\Acl
 {
     public function exroleDFSVisitAllPrivileges(
         Acl\Role\RoleInterface $role,
-        Acl\Resource\ResourceInterface $resource = null,
+        ?Acl\Resource\ResourceInterface $resource = null,
         &$dfs = null
     ) {
-
         return $this->roleDFSVisitAllPrivileges($role, $resource, $dfs);
     }
 
     public function exroleDFSOnePrivilege(
         Acl\Role\RoleInterface $role,
-        Acl\Resource\ResourceInterface $resource = null,
+        ?Acl\Resource\ResourceInterface $resource = null,
         $privilege = null
     ) {
-
         return $this->roleDFSOnePrivilege($role, $resource, $privilege);
     }
 
     public function exroleDFSVisitOnePrivilege(
         Acl\Role\RoleInterface $role,
-        Acl\Resource\ResourceInterface $resource = null,
+        ?Acl\Resource\ResourceInterface $resource = null,
         $privilege = null,
         &$dfs = null
     ) {
-
         return $this->roleDFSVisitOnePrivilege($role, $resource, $privilege, $dfs);
     }
 }

--- a/test/TestAsset/ExtendedAclLaminas2234.php
+++ b/test/TestAsset/ExtendedAclLaminas2234.php
@@ -1,10 +1,10 @@
 <?php
 
-declare(strict_types=1);
-
 /**
- * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
+ * @see https://github.com/laminas/laminas-permissions-acl for the canonical source repository
  */
+
+declare(strict_types=1);
 
 namespace LaminasTest\Permissions\Acl\TestAsset;
 

--- a/test/TestAsset/ExtendedAclLaminas2234.php
+++ b/test/TestAsset/ExtendedAclLaminas2234.php
@@ -12,28 +12,38 @@ use Laminas\Permissions\Acl;
 
 class ExtendedAclLaminas2234 extends Acl\Acl
 {
+    /**
+     * @param  mixed|null  $dfs
+     */
     public function exroleDFSVisitAllPrivileges(
         Acl\Role\RoleInterface $role,
         ?Acl\Resource\ResourceInterface $resource = null,
         &$dfs = null
-    ) {
+    ): ?bool {
         return $this->roleDFSVisitAllPrivileges($role, $resource, $dfs);
     }
 
+    /**
+     * @param  mixed|null  $privilege
+     */
     public function exroleDFSOnePrivilege(
         Acl\Role\RoleInterface $role,
         ?Acl\Resource\ResourceInterface $resource = null,
         $privilege = null
-    ) {
+    ): ?bool {
         return $this->roleDFSOnePrivilege($role, $resource, $privilege);
     }
 
+    /**
+     * @param  mixed|null  $privilege
+     * @param  mixed|null  $dfs
+     */
     public function exroleDFSVisitOnePrivilege(
         Acl\Role\RoleInterface $role,
         ?Acl\Resource\ResourceInterface $resource = null,
         $privilege = null,
         &$dfs = null
-    ) {
+    ): ?bool {
         return $this->roleDFSVisitOnePrivilege($role, $resource, $privilege, $dfs);
     }
 }

--- a/test/TestAsset/MockAssertion.php
+++ b/test/TestAsset/MockAssertion.php
@@ -1,9 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
- * @copyright https://github.com/laminas/laminas-permissions-acl/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-permissions-acl/blob/master/LICENSE.md New BSD License
  */
 
 namespace LaminasTest\Permissions\Acl\TestAsset;
@@ -21,11 +21,10 @@ class MockAssertion implements Acl\Assertion\AssertionInterface
 
     public function assert(
         Acl\Acl $acl,
-        Acl\Role\RoleInterface $role = null,
-        Acl\Resource\ResourceInterface $resource = null,
+        ?Acl\Role\RoleInterface $role = null,
+        ?Acl\Resource\ResourceInterface $resource = null,
         $privilege = null
     ) {
-
         return $this->returnValue;
     }
 }

--- a/test/TestAsset/MockAssertion.php
+++ b/test/TestAsset/MockAssertion.php
@@ -12,19 +12,19 @@ use Laminas\Permissions\Acl;
 
 class MockAssertion implements Acl\Assertion\AssertionInterface
 {
-    protected $returnValue;
+    protected bool $returnValue;
 
-    public function __construct($returnValue)
+    public function __construct(bool $returnValue)
     {
-        $this->returnValue = (bool) $returnValue;
+        $this->returnValue = $returnValue;
     }
 
     public function assert(
         Acl\Acl $acl,
         ?Acl\Role\RoleInterface $role = null,
         ?Acl\Resource\ResourceInterface $resource = null,
-        $privilege = null
-    ) {
+        ?string $privilege = null
+    ): bool {
         return $this->returnValue;
     }
 }

--- a/test/TestAsset/MockAssertion.php
+++ b/test/TestAsset/MockAssertion.php
@@ -1,10 +1,10 @@
 <?php
 
-declare(strict_types=1);
-
 /**
- * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
+ * @see https://github.com/laminas/laminas-permissions-acl for the canonical source repository
  */
+
+declare(strict_types=1);
 
 namespace LaminasTest\Permissions\Acl\TestAsset;
 

--- a/test/TestAsset/OwnershipUseCase/Acl.php
+++ b/test/TestAsset/OwnershipUseCase/Acl.php
@@ -1,10 +1,10 @@
 <?php
 
-declare(strict_types=1);
-
 /**
- * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
+ * @see https://github.com/laminas/laminas-permissions-acl for the canonical source repository
  */
+
+declare(strict_types=1);
 
 namespace LaminasTest\Permissions\Acl\TestAsset\OwnershipUseCase;
 

--- a/test/TestAsset/OwnershipUseCase/Acl.php
+++ b/test/TestAsset/OwnershipUseCase/Acl.php
@@ -1,9 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
- * @copyright https://github.com/laminas/laminas-permissions-acl/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-permissions-acl/blob/master/LICENSE.md New BSD License
  */
 
 namespace LaminasTest\Permissions\Acl\TestAsset\OwnershipUseCase;

--- a/test/TestAsset/OwnershipUseCase/Author1.php
+++ b/test/TestAsset/OwnershipUseCase/Author1.php
@@ -1,10 +1,10 @@
 <?php
 
-declare(strict_types=1);
-
 /**
- * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
+ * @see https://github.com/laminas/laminas-permissions-acl for the canonical source repository
  */
+
+declare(strict_types=1);
 
 namespace LaminasTest\Permissions\Acl\TestAsset\OwnershipUseCase;
 

--- a/test/TestAsset/OwnershipUseCase/Author1.php
+++ b/test/TestAsset/OwnershipUseCase/Author1.php
@@ -10,7 +10,7 @@ namespace LaminasTest\Permissions\Acl\TestAsset\OwnershipUseCase;
 
 class Author1 extends User
 {
-    public $id = 1;
+    public int $id = 1;
 
-    public $role = 'author';
+    public string $role = 'author';
 }

--- a/test/TestAsset/OwnershipUseCase/Author1.php
+++ b/test/TestAsset/OwnershipUseCase/Author1.php
@@ -1,9 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
- * @copyright https://github.com/laminas/laminas-permissions-acl/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-permissions-acl/blob/master/LICENSE.md New BSD License
  */
 
 namespace LaminasTest\Permissions\Acl\TestAsset\OwnershipUseCase;

--- a/test/TestAsset/OwnershipUseCase/Author2.php
+++ b/test/TestAsset/OwnershipUseCase/Author2.php
@@ -1,10 +1,10 @@
 <?php
 
-declare(strict_types=1);
-
 /**
- * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
+ * @see https://github.com/laminas/laminas-permissions-acl for the canonical source repository
  */
+
+declare(strict_types=1);
 
 namespace LaminasTest\Permissions\Acl\TestAsset\OwnershipUseCase;
 

--- a/test/TestAsset/OwnershipUseCase/Author2.php
+++ b/test/TestAsset/OwnershipUseCase/Author2.php
@@ -10,7 +10,7 @@ namespace LaminasTest\Permissions\Acl\TestAsset\OwnershipUseCase;
 
 class Author2 extends User
 {
-    public $id = 2;
+    public int $id = 2;
 
-    public $role = 'author';
+    public string $role = 'author';
 }

--- a/test/TestAsset/OwnershipUseCase/Author2.php
+++ b/test/TestAsset/OwnershipUseCase/Author2.php
@@ -1,9 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
- * @copyright https://github.com/laminas/laminas-permissions-acl/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-permissions-acl/blob/master/LICENSE.md New BSD License
  */
 
 namespace LaminasTest\Permissions\Acl\TestAsset\OwnershipUseCase;

--- a/test/TestAsset/OwnershipUseCase/BlogPost.php
+++ b/test/TestAsset/OwnershipUseCase/BlogPost.php
@@ -1,10 +1,10 @@
 <?php
 
-declare(strict_types=1);
-
 /**
- * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
+ * @see https://github.com/laminas/laminas-permissions-acl for the canonical source repository
  */
+
+declare(strict_types=1);
 
 namespace LaminasTest\Permissions\Acl\TestAsset\OwnershipUseCase;
 

--- a/test/TestAsset/OwnershipUseCase/BlogPost.php
+++ b/test/TestAsset/OwnershipUseCase/BlogPost.php
@@ -13,13 +13,16 @@ use Laminas\Permissions\Acl\Resource\ResourceInterface;
 
 class BlogPost implements ResourceInterface, ProprietaryInterface
 {
-    public $author;
+    public ?User $author;
 
-    public function getResourceId()
+    public function getResourceId(): string
     {
         return 'blogPost';
     }
 
+    /**
+     * @return mixed|null
+     */
     public function getOwnerId()
     {
         if ($this->author === null) {

--- a/test/TestAsset/OwnershipUseCase/BlogPost.php
+++ b/test/TestAsset/OwnershipUseCase/BlogPost.php
@@ -1,9 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
- * @copyright https://github.com/laminas/laminas-permissions-acl/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-permissions-acl/blob/master/LICENSE.md New BSD License
  */
 
 namespace LaminasTest\Permissions\Acl\TestAsset\OwnershipUseCase;
@@ -13,7 +13,7 @@ use Laminas\Permissions\Acl\Resource\ResourceInterface;
 
 class BlogPost implements ResourceInterface, ProprietaryInterface
 {
-    public $author = null;
+    public $author;
 
     public function getResourceId()
     {

--- a/test/TestAsset/OwnershipUseCase/Comment.php
+++ b/test/TestAsset/OwnershipUseCase/Comment.php
@@ -1,10 +1,10 @@
 <?php
 
-declare(strict_types=1);
-
 /**
- * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
+ * @see https://github.com/laminas/laminas-permissions-acl for the canonical source repository
  */
+
+declare(strict_types=1);
 
 namespace LaminasTest\Permissions\Acl\TestAsset\OwnershipUseCase;
 

--- a/test/TestAsset/OwnershipUseCase/Comment.php
+++ b/test/TestAsset/OwnershipUseCase/Comment.php
@@ -12,7 +12,7 @@ use Laminas\Permissions\Acl\Resource\ResourceInterface;
 
 class Comment implements ResourceInterface
 {
-    public function getResourceId()
+    public function getResourceId(): string
     {
         return 'comment';
     }

--- a/test/TestAsset/OwnershipUseCase/Comment.php
+++ b/test/TestAsset/OwnershipUseCase/Comment.php
@@ -1,9 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
- * @copyright https://github.com/laminas/laminas-permissions-acl/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-permissions-acl/blob/master/LICENSE.md New BSD License
  */
 
 namespace LaminasTest\Permissions\Acl\TestAsset\OwnershipUseCase;

--- a/test/TestAsset/OwnershipUseCase/User.php
+++ b/test/TestAsset/OwnershipUseCase/User.php
@@ -1,10 +1,10 @@
 <?php
 
-declare(strict_types=1);
-
 /**
- * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
+ * @see https://github.com/laminas/laminas-permissions-acl for the canonical source repository
  */
+
+declare(strict_types=1);
 
 namespace LaminasTest\Permissions\Acl\TestAsset\OwnershipUseCase;
 

--- a/test/TestAsset/OwnershipUseCase/User.php
+++ b/test/TestAsset/OwnershipUseCase/User.php
@@ -13,16 +13,16 @@ use Laminas\Permissions\Acl\Role\RoleInterface;
 
 class User implements RoleInterface, ProprietaryInterface
 {
-    public $id;
+    public int $id;
 
-    public $role = 'guest';
+    public string $role = 'guest';
 
-    public function getRoleId()
+    public function getRoleId(): string
     {
         return $this->role;
     }
 
-    public function getOwnerId()
+    public function getOwnerId(): int
     {
         return $this->id;
     }

--- a/test/TestAsset/OwnershipUseCase/User.php
+++ b/test/TestAsset/OwnershipUseCase/User.php
@@ -1,9 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
- * @copyright https://github.com/laminas/laminas-permissions-acl/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-permissions-acl/blob/master/LICENSE.md New BSD License
  */
 
 namespace LaminasTest\Permissions\Acl\TestAsset\OwnershipUseCase;

--- a/test/TestAsset/StandardUseCase/Acl.php
+++ b/test/TestAsset/StandardUseCase/Acl.php
@@ -1,9 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
- * @copyright https://github.com/laminas/laminas-permissions-acl/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-permissions-acl/blob/master/LICENSE.md New BSD License
  */
 
 namespace LaminasTest\Permissions\Acl\TestAsset\StandardUseCase;
@@ -14,7 +14,7 @@ use Laminas\Permissions\Acl\Role\GenericRole;
 
 class Acl extends BaseAcl
 {
-    public $customAssertion = null;
+    public $customAssertion;
 
     public function __construct()
     {

--- a/test/TestAsset/StandardUseCase/Acl.php
+++ b/test/TestAsset/StandardUseCase/Acl.php
@@ -1,10 +1,10 @@
 <?php
 
-declare(strict_types=1);
-
 /**
- * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
+ * @see https://github.com/laminas/laminas-permissions-acl for the canonical source repository
  */
+
+declare(strict_types=1);
 
 namespace LaminasTest\Permissions\Acl\TestAsset\StandardUseCase;
 

--- a/test/TestAsset/StandardUseCase/Acl.php
+++ b/test/TestAsset/StandardUseCase/Acl.php
@@ -14,7 +14,7 @@ use Laminas\Permissions\Acl\Role\GenericRole;
 
 class Acl extends BaseAcl
 {
-    public $customAssertion;
+    public UserIsBlogPostOwnerAssertion $customAssertion;
 
     public function __construct()
     {

--- a/test/TestAsset/StandardUseCase/BlogPost.php
+++ b/test/TestAsset/StandardUseCase/BlogPost.php
@@ -1,10 +1,10 @@
 <?php
 
-declare(strict_types=1);
-
 /**
- * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
+ * @see https://github.com/laminas/laminas-permissions-acl for the canonical source repository
  */
+
+declare(strict_types=1);
 
 namespace LaminasTest\Permissions\Acl\TestAsset\StandardUseCase;
 

--- a/test/TestAsset/StandardUseCase/BlogPost.php
+++ b/test/TestAsset/StandardUseCase/BlogPost.php
@@ -12,9 +12,7 @@ use Laminas\Permissions\Acl\Resource\ResourceInterface;
 
 class BlogPost implements ResourceInterface
 {
-    public $owner;
-
-    public function getResourceId()
+    public function getResourceId(): string
     {
         return 'blogPost';
     }

--- a/test/TestAsset/StandardUseCase/BlogPost.php
+++ b/test/TestAsset/StandardUseCase/BlogPost.php
@@ -1,9 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
- * @copyright https://github.com/laminas/laminas-permissions-acl/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-permissions-acl/blob/master/LICENSE.md New BSD License
  */
 
 namespace LaminasTest\Permissions\Acl\TestAsset\StandardUseCase;
@@ -12,7 +12,7 @@ use Laminas\Permissions\Acl\Resource\ResourceInterface;
 
 class BlogPost implements ResourceInterface
 {
-    public $owner = null;
+    public $owner;
 
     public function getResourceId()
     {

--- a/test/TestAsset/StandardUseCase/User.php
+++ b/test/TestAsset/StandardUseCase/User.php
@@ -1,9 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
- * @copyright https://github.com/laminas/laminas-permissions-acl/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-permissions-acl/blob/master/LICENSE.md New BSD License
  */
 
 namespace LaminasTest\Permissions\Acl\TestAsset\StandardUseCase;

--- a/test/TestAsset/StandardUseCase/User.php
+++ b/test/TestAsset/StandardUseCase/User.php
@@ -12,9 +12,9 @@ use Laminas\Permissions\Acl\Role\RoleInterface;
 
 class User implements RoleInterface
 {
-    public $role = 'guest';
+    public string $role = 'guest';
 
-    public function getRoleId()
+    public function getRoleId(): string
     {
         return $this->role;
     }

--- a/test/TestAsset/StandardUseCase/User.php
+++ b/test/TestAsset/StandardUseCase/User.php
@@ -1,10 +1,10 @@
 <?php
 
-declare(strict_types=1);
-
 /**
- * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
+ * @see https://github.com/laminas/laminas-permissions-acl for the canonical source repository
  */
+
+declare(strict_types=1);
 
 namespace LaminasTest\Permissions\Acl\TestAsset\StandardUseCase;
 

--- a/test/TestAsset/StandardUseCase/UserIsBlogPostOwnerAssertion.php
+++ b/test/TestAsset/StandardUseCase/UserIsBlogPostOwnerAssertion.php
@@ -1,9 +1,9 @@
 <?php
 
+declare(strict_types=1);
+
 /**
  * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
- * @copyright https://github.com/laminas/laminas-permissions-acl/blob/master/COPYRIGHT.md
- * @license   https://github.com/laminas/laminas-permissions-acl/blob/master/LICENSE.md New BSD License
  */
 
 namespace LaminasTest\Permissions\Acl\TestAsset\StandardUseCase;
@@ -15,15 +15,15 @@ use Laminas\Permissions\Acl\Role\RoleInterface;
 
 class UserIsBlogPostOwnerAssertion implements AssertionInterface
 {
-    public $lastAssertRole = null;
-    public $lastAssertResource = null;
-    public $lastAssertPrivilege = null;
+    public $lastAssertRole;
+    public $lastAssertResource;
+    public $lastAssertPrivilege;
     public $assertReturnValue = true;
 
     public function assert(
         LaminasAcl $acl,
-        RoleInterface $user = null,
-        ResourceInterface $blogPost = null,
+        ?RoleInterface $user = null,
+        ?ResourceInterface $blogPost = null,
         $privilege = null
     ) {
         $this->lastAssertRole      = $user;

--- a/test/TestAsset/StandardUseCase/UserIsBlogPostOwnerAssertion.php
+++ b/test/TestAsset/StandardUseCase/UserIsBlogPostOwnerAssertion.php
@@ -1,10 +1,10 @@
 <?php
 
-declare(strict_types=1);
-
 /**
- * @see       https://github.com/laminas/laminas-permissions-acl for the canonical source repository
+ * @see https://github.com/laminas/laminas-permissions-acl for the canonical source repository
  */
+
+declare(strict_types=1);
 
 namespace LaminasTest\Permissions\Acl\TestAsset\StandardUseCase;
 

--- a/test/TestAsset/StandardUseCase/UserIsBlogPostOwnerAssertion.php
+++ b/test/TestAsset/StandardUseCase/UserIsBlogPostOwnerAssertion.php
@@ -15,19 +15,21 @@ use Laminas\Permissions\Acl\Role\RoleInterface;
 
 class UserIsBlogPostOwnerAssertion implements AssertionInterface
 {
-    public $lastAssertRole;
-    public $lastAssertResource;
+    public ?RoleInterface $lastAssertRole;
+    public ?ResourceInterface $lastAssertResource;
+
+    /** @var mixed|null */
     public $lastAssertPrivilege;
-    public $assertReturnValue = true;
+    public bool $assertReturnValue = true;
 
     public function assert(
         LaminasAcl $acl,
-        ?RoleInterface $user = null,
-        ?ResourceInterface $blogPost = null,
-        $privilege = null
-    ) {
-        $this->lastAssertRole      = $user;
-        $this->lastAssertResource  = $blogPost;
+        ?RoleInterface $role = null,
+        ?ResourceInterface $resource = null,
+        ?string $privilege = null
+    ): bool {
+        $this->lastAssertRole      = $role;
+        $this->lastAssertResource  = $resource;
         $this->lastAssertPrivilege = $privilege;
         return $this->assertReturnValue;
     }


### PR DESCRIPTION
<!--
Fill in the relevant information below to help triage your issue.

Pick the target branch based on the following criteria:
  * Documentation improvement: master branch
  * Bugfix: master branch
  * QA improvement (additional tests, CS fixes, etc.) that does not change code
    behavior: master branch
  * New feature, or refactor of existing code: develop branch

You MUST provide a signoff in your commits for us to be able to accept your
patch; you can do this by providing either the --signoff or -s flag when using
"git commit". Please see the project contributing guide and
https://developercertificate.org for details.
-->

|    Q          |   A
|-------------- | ------
| Documentation | no
| Bugfix        | no
| BC Break      | no
| New Feature   | yes
| RFC           | no
| QA            | yes

### Description

<!--
Tell us about why this change is necessary:
- Are you fixing a bug or providing a failing unit test to demonstrate a bug?
  - How do you reproduce it?
  - What did you expect to happen?
  - What actually happened?
  - TARGET THE master BRANCH

- Are you adding documentation?
  - TARGET THE master BRANCH

- Are you providing a QA improvement (additional tests, CS fixes, etc.) that
  does not change behavior?
  - Explain why the changes are necessary
  - TARGET THE master BRANCH

- Are you fixing a BC Break?
  - How do you reproduce it?
  - What was the previous behavior?
  - What is the current behavior?
  - TARGET THE master BRANCH

- Are you adding something the library currently does not support?
  - Why should it be added?
  - What will it enable?
  - How will the code be used?
  - TARGET THE develop BRANCH

- Are you refactoring code?
  - Why do you feel the refactor is necessary?
  - What types of refactoring are you doing?
  - TARGET THE develop BRANCH
-->
This pull request solves #24 by adding support for PHP 8.1: bumped dependencies (follow to commit messages - every dependency update commited separately). According to bump of [laminas/laminas-coding-standard](https://github.com/laminas/laminas-coding-standard) to new major version with updated ruleset there was many code style errors and warnings. I also fixed this.

Next, dropped support for PHP 7.3 because of it was incompatible with [laminas/laminas-servicemanager](https://github.com/laminas/laminas-servicemanager) what already requires minimum PHP 7.4. Furthermore, official support of 7.3 [will end soon](https://www.php.net/supported-versions.php).
