### PR TITLE
Upgrade to `laminas-servicemanager:4.0`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,11 +33,11 @@
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~2.5.0",
-        "laminas/laminas-servicemanager": "^3.21",
-        "phpbench/phpbench": "^1.2.10",
-        "phpunit/phpunit": "^10.1.3",
+        "laminas/laminas-servicemanager": "^4.0",
+        "phpbench/phpbench": "^1.2.15",
+        "phpunit/phpunit": "^10.5.11",
         "psalm/plugin-phpunit": "^0.18.4",
-        "vimeo/psalm": "^5.12"
+        "vimeo/psalm": "^5.22.2"
     },
     "suggest": {
         "laminas/laminas-servicemanager": "To support Laminas\\Permissions\\Acl\\Assertion\\AssertionManager plugin manager usage"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "53d69430adebd0214b8c7e263ca44594",
+    "content-hash": "67e441be0a86ef7f6d1f26a6ae629f81",
     "packages": [],
     "packages-dev": [
         {
@@ -172,6 +172,55 @@
                 }
             ],
             "time": "2021-03-30T17:13:30+00:00"
+        },
+        {
+            "name": "brick/varexporter",
+            "version": "0.4.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/brick/varexporter.git",
+                "reference": "2fd038f7c9d12d468130c6e1b3ce06e4160a7dbb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/brick/varexporter/zipball/2fd038f7c9d12d468130c6e1b3ce06e4160a7dbb",
+                "reference": "2fd038f7c9d12d468130c6e1b3ce06e4160a7dbb",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.0",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "php-coveralls/php-coveralls": "^2.2",
+                "phpunit/phpunit": "^8.5 || ^9.0",
+                "vimeo/psalm": "5.15.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Brick\\VarExporter\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A powerful alternative to var_export(), which can export closures and objects without __set_state()",
+            "keywords": [
+                "var_export"
+            ],
+            "support": {
+                "issues": "https://github.com/brick/varexporter/issues",
+                "source": "https://github.com/brick/varexporter/tree/0.4.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/BenMorel",
+                    "type": "github"
+                }
+            ],
+            "time": "2023-09-01T21:10:07+00:00"
         },
         {
             "name": "composer/package-versions-deprecated",
@@ -949,59 +998,58 @@
         },
         {
             "name": "laminas/laminas-servicemanager",
-            "version": "3.22.1",
+            "version": "4.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-servicemanager.git",
-                "reference": "de98d297d4743956a0558a6d71616979ff779328"
+                "reference": "aa4b0f55004c85ed8bf9883050b43a14c8335b5c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/de98d297d4743956a0558a6d71616979ff779328",
-                "reference": "de98d297d4743956a0558a6d71616979ff779328",
+                "url": "https://api.github.com/repos/laminas/laminas-servicemanager/zipball/aa4b0f55004c85ed8bf9883050b43a14c8335b5c",
+                "reference": "aa4b0f55004c85ed8bf9883050b43a14c8335b5c",
                 "shasum": ""
             },
             "require": {
+                "brick/varexporter": "^0.3.8 || ^0.4.0",
                 "laminas/laminas-stdlib": "^3.17",
                 "php": "~8.1.0 || ~8.2.0 || ~8.3.0",
-                "psr/container": "^1.0"
+                "psr/container": "^1.1 || ^2.0"
             },
             "conflict": {
-                "ext-psr": "*",
                 "laminas/laminas-code": "<4.10.0",
-                "zendframework/zend-code": "<3.3.1",
-                "zendframework/zend-servicemanager": "*"
+                "zendframework/zend-code": "<3.3.1"
             },
             "provide": {
-                "psr/container-implementation": "^1.0"
-            },
-            "replace": {
-                "container-interop/container-interop": "^1.2.0"
+                "psr/container-implementation": "^1.0 || ^2.0"
             },
             "require-dev": {
+                "boesing/psalm-plugin-stringf": "^1.4",
                 "composer/package-versions-deprecated": "^1.11.99.5",
-                "friendsofphp/proxy-manager-lts": "^1.0.14",
-                "laminas/laminas-code": "^4.10.0",
+                "friendsofphp/proxy-manager-lts": "^1",
+                "laminas/laminas-cli": "^1.8",
                 "laminas/laminas-coding-standard": "~2.5.0",
-                "laminas/laminas-container-config-test": "^0.8",
-                "mikey179/vfsstream": "^1.6.11",
-                "phpbench/phpbench": "^1.2.9",
+                "laminas/laminas-container-config-test": "^1.0",
+                "lctrs/psalm-psr-container-plugin": "^1.9",
+                "mikey179/vfsstream": "^1.6.11@alpha",
+                "phpbench/phpbench": "^1.2.7",
                 "phpunit/phpunit": "^10.4",
                 "psalm/plugin-phpunit": "^0.18.4",
-                "vimeo/psalm": "^5.8.0"
+                "symfony/console": "^6.0",
+                "vimeo/psalm": "^5.22"
             },
             "suggest": {
-                "friendsofphp/proxy-manager-lts": "ProxyManager ^2.1.1 to handle lazy initialization of services"
+                "friendsofphp/proxy-manager-lts": "To handle lazy initialization of services",
+                "laminas/laminas-cli": "To consume CLI commands provided by this component"
             },
-            "bin": [
-                "bin/generate-deps-for-config-factory",
-                "bin/generate-factory-for-class"
-            ],
             "type": "library",
+            "extra": {
+                "laminas": {
+                    "config-provider": "Laminas\\ServiceManager\\ConfigProvider",
+                    "module": "Laminas\\ServiceManager"
+                }
+            },
             "autoload": {
-                "files": [
-                    "src/autoload.php"
-                ],
                 "psr-4": {
                     "Laminas\\ServiceManager\\": "src/"
                 }
@@ -1023,11 +1071,9 @@
             ],
             "support": {
                 "chat": "https://laminas.dev/chat",
-                "docs": "https://docs.laminas.dev/laminas-servicemanager/",
                 "forum": "https://discourse.laminas.dev",
                 "issues": "https://github.com/laminas/laminas-servicemanager/issues",
-                "rss": "https://github.com/laminas/laminas-servicemanager/releases.atom",
-                "source": "https://github.com/laminas/laminas-servicemanager"
+                "source": "https://github.com/laminas/laminas-servicemanager/tree/4.0.0"
             },
             "funding": [
                 {
@@ -1035,7 +1081,7 @@
                     "type": "community_bridge"
                 }
             ],
-            "time": "2023-10-24T11:19:47+00:00"
+            "time": "2024-03-04T08:57:26+00:00"
         },
         {
             "name": "laminas/laminas-stdlib",
@@ -2322,22 +2368,27 @@
         },
         {
             "name": "psr/container",
-            "version": "1.1.2",
+            "version": "2.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-fig/container.git",
-                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea"
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-fig/container/zipball/513e0666f7216c7459170d56df27dfcefe1689ea",
-                "reference": "513e0666f7216c7459170d56df27dfcefe1689ea",
+                "url": "https://api.github.com/repos/php-fig/container/zipball/c71ecc56dfe541dbd90c5360474fbc405f8d5963",
+                "reference": "c71ecc56dfe541dbd90c5360474fbc405f8d5963",
                 "shasum": ""
             },
             "require": {
                 "php": ">=7.4.0"
             },
             "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.0.x-dev"
+                }
+            },
             "autoload": {
                 "psr-4": {
                     "Psr\\Container\\": "src/"
@@ -2364,9 +2415,9 @@
             ],
             "support": {
                 "issues": "https://github.com/php-fig/container/issues",
-                "source": "https://github.com/php-fig/container/tree/1.1.2"
+                "source": "https://github.com/php-fig/container/tree/2.0.2"
             },
-            "time": "2021-11-05T16:50:12+00:00"
+            "time": "2021-11-05T16:47:00+00:00"
         },
         {
             "name": "psr/log",

--- a/psalm-baseline.xml
+++ b/psalm-baseline.xml
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<files psalm-version="5.14.1@b9d355e0829c397b9b3b47d0c0ed042a8a70284d">
+<files psalm-version="5.22.2@d768d914152dbbf3486c36398802f74e80cfde48">
   <file src="src/Acl.php">
     <MixedArgument>
-      <code>$child</code>
-      <code>$childId</code>
+      <code><![CDATA[$child]]></code>
+      <code><![CDATA[$childId]]></code>
       <code><![CDATA[$dfs['stack']]]></code>
       <code><![CDATA[$dfs['stack']]]></code>
-      <code>$privilege</code>
-      <code>$privilege</code>
-      <code>$resource</code>
-      <code>$resource</code>
-      <code>$resource</code>
-      <code>$resource</code>
-      <code>$resource</code>
-      <code>$role</code>
-      <code>$role</code>
-      <code>$role</code>
-      <code>$visitor</code>
+      <code><![CDATA[$privilege]]></code>
+      <code><![CDATA[$privilege]]></code>
+      <code><![CDATA[$resource]]></code>
+      <code><![CDATA[$resource]]></code>
+      <code><![CDATA[$resource]]></code>
+      <code><![CDATA[$resource]]></code>
+      <code><![CDATA[$resource]]></code>
+      <code><![CDATA[$role]]></code>
+      <code><![CDATA[$role]]></code>
+      <code><![CDATA[$role]]></code>
+      <code><![CDATA[$visitor]]></code>
     </MixedArgument>
     <MixedArrayAccess>
       <code><![CDATA[$rule['assert']]]></code>
@@ -81,60 +81,60 @@
       <code><![CDATA[$this->rules['byResourceId'][$resourceIdCurrent]['byRoleId'][$roleIdCurrent]]]></code>
     </MixedArrayOffset>
     <MixedAssignment>
-      <code>$child</code>
-      <code>$child</code>
-      <code>$childId</code>
-      <code>$children</code>
+      <code><![CDATA[$child]]></code>
+      <code><![CDATA[$child]]></code>
+      <code><![CDATA[$childId]]></code>
+      <code><![CDATA[$children]]></code>
       <code><![CDATA[$dfs['stack'][]]]></code>
       <code><![CDATA[$dfs['stack'][]]]></code>
-      <code>$parentId</code>
-      <code>$parentId</code>
-      <code>$privilege</code>
-      <code>$privilege</code>
-      <code>$privilege</code>
-      <code>$privilege</code>
-      <code>$resource</code>
-      <code>$resource</code>
-      <code>$resource</code>
-      <code>$resource</code>
-      <code>$resourceIdCurrent</code>
-      <code>$resourceIdCurrent</code>
-      <code>$resourceIdCurrent</code>
-      <code>$resourceIdRemoved</code>
-      <code>$resourceParent</code>
-      <code>$resourcesRemoved[]</code>
-      <code>$role</code>
-      <code>$role</code>
-      <code>$role</code>
-      <code>$roleIdCurrent</code>
-      <code>$roleIdCurrent</code>
-      <code>$roleIdCurrent</code>
-      <code>$roleIdCurrent</code>
-      <code>$roleParent</code>
-      <code>$roleParent</code>
-      <code>$rule</code>
-      <code>$rule</code>
-      <code>$rule</code>
-      <code>$rule</code>
-      <code>$rules</code>
-      <code>$rules</code>
-      <code>$rules</code>
-      <code>$rules</code>
-      <code>$rules</code>
-      <code>$visitor</code>
-      <code>$visitor</code>
+      <code><![CDATA[$parentId]]></code>
+      <code><![CDATA[$parentId]]></code>
+      <code><![CDATA[$privilege]]></code>
+      <code><![CDATA[$privilege]]></code>
+      <code><![CDATA[$privilege]]></code>
+      <code><![CDATA[$privilege]]></code>
+      <code><![CDATA[$resource]]></code>
+      <code><![CDATA[$resource]]></code>
+      <code><![CDATA[$resource]]></code>
+      <code><![CDATA[$resource]]></code>
+      <code><![CDATA[$resourceIdCurrent]]></code>
+      <code><![CDATA[$resourceIdCurrent]]></code>
+      <code><![CDATA[$resourceIdCurrent]]></code>
+      <code><![CDATA[$resourceIdRemoved]]></code>
+      <code><![CDATA[$resourceParent]]></code>
+      <code><![CDATA[$resourcesRemoved[]]]></code>
+      <code><![CDATA[$role]]></code>
+      <code><![CDATA[$role]]></code>
+      <code><![CDATA[$role]]></code>
+      <code><![CDATA[$roleIdCurrent]]></code>
+      <code><![CDATA[$roleIdCurrent]]></code>
+      <code><![CDATA[$roleIdCurrent]]></code>
+      <code><![CDATA[$roleIdCurrent]]></code>
+      <code><![CDATA[$roleParent]]></code>
+      <code><![CDATA[$roleParent]]></code>
+      <code><![CDATA[$rule]]></code>
+      <code><![CDATA[$rule]]></code>
+      <code><![CDATA[$rule]]></code>
+      <code><![CDATA[$rule]]></code>
+      <code><![CDATA[$rules]]></code>
+      <code><![CDATA[$rules]]></code>
+      <code><![CDATA[$rules]]></code>
+      <code><![CDATA[$rules]]></code>
+      <code><![CDATA[$rules]]></code>
+      <code><![CDATA[$visitor]]></code>
+      <code><![CDATA[$visitor]]></code>
     </MixedAssignment>
     <MixedInferredReturnType>
-      <code>ResourceInterface</code>
-      <code>array|null</code>
-      <code>string|null</code>
+      <code><![CDATA[ResourceInterface]]></code>
+      <code><![CDATA[array|null]]></code>
+      <code><![CDATA[string|null]]></code>
     </MixedInferredReturnType>
     <MixedMethodCall>
-      <code>getResourceId</code>
-      <code>getResourceId</code>
-      <code>getResourceId</code>
-      <code>getRoleId</code>
-      <code>getRoleId</code>
+      <code><![CDATA[getResourceId]]></code>
+      <code><![CDATA[getResourceId]]></code>
+      <code><![CDATA[getResourceId]]></code>
+      <code><![CDATA[getRoleId]]></code>
+      <code><![CDATA[getRoleId]]></code>
     </MixedMethodCall>
     <MixedReturnStatement>
       <code><![CDATA[$rule['type']]]></code>
@@ -145,8 +145,8 @@
       <code><![CDATA[$visitor['byRoleId'][$roleId]]]></code>
     </MixedReturnStatement>
     <PossiblyInvalidPropertyAssignmentValue>
-      <code>$resource</code>
-      <code>$role</code>
+      <code><![CDATA[$resource]]></code>
+      <code><![CDATA[$role]]></code>
     </PossiblyInvalidPropertyAssignmentValue>
     <PossiblyNullArgument>
       <code><![CDATA[$dfs['stack']]]></code>
@@ -161,22 +161,22 @@
       <code><![CDATA[$rules['byPrivilegeId']]]></code>
     </PossiblyNullArrayAssignment>
     <PossiblyNullReference>
-      <code>getResourceId</code>
-      <code>getResourceId</code>
+      <code><![CDATA[getResourceId]]></code>
+      <code><![CDATA[getResourceId]]></code>
     </PossiblyNullReference>
     <PossiblyUndefinedVariable>
-      <code>$resourceParentId</code>
+      <code><![CDATA[$resourceParentId]]></code>
     </PossiblyUndefinedVariable>
     <PossiblyUnusedMethod>
-      <code>getChildResources</code>
+      <code><![CDATA[getChildResources]]></code>
     </PossiblyUnusedMethod>
     <PossiblyUnusedReturnValue>
-      <code>Acl</code>
-      <code>Acl</code>
+      <code><![CDATA[Acl]]></code>
+      <code><![CDATA[Acl]]></code>
     </PossiblyUnusedReturnValue>
     <RedundantCastGivenDocblockType>
-      <code>(string) $resource</code>
-      <code>(string) $resource</code>
+      <code><![CDATA[(string) $resource]]></code>
+      <code><![CDATA[(string) $resource]]></code>
     </RedundantCastGivenDocblockType>
     <UnsupportedPropertyReferenceUsage>
       <code><![CDATA[$visitor =& $this->rules['allResources']]]></code>
@@ -187,63 +187,52 @@
       <code><![CDATA[$rules =& $this->getRules($resource, $role, true)]]></code>
     </UnsupportedReferenceUsage>
     <UnusedForeachValue>
-      <code>$child</code>
-      <code>$resource</code>
-      <code>$rule</code>
-      <code>$rule</code>
-      <code>$rules</code>
-      <code>$rules</code>
-      <code>$rules</code>
-      <code>$rules</code>
-      <code>$rules</code>
+      <code><![CDATA[$child]]></code>
+      <code><![CDATA[$resource]]></code>
+      <code><![CDATA[$rule]]></code>
+      <code><![CDATA[$rule]]></code>
+      <code><![CDATA[$rules]]></code>
+      <code><![CDATA[$rules]]></code>
+      <code><![CDATA[$rules]]></code>
+      <code><![CDATA[$rules]]></code>
+      <code><![CDATA[$rules]]></code>
     </UnusedForeachValue>
     <UnusedVariable>
-      <code>$rules</code>
+      <code><![CDATA[$rules]]></code>
     </UnusedVariable>
   </file>
   <file src="src/Assertion/AssertionAggregate.php">
     <MixedAssignment>
-      <code>$assertion</code>
+      <code><![CDATA[$assertion]]></code>
     </MixedAssignment>
     <MixedMethodCall>
-      <code>assert</code>
-      <code>new $assertion()</code>
+      <code><![CDATA[assert]]></code>
+      <code><![CDATA[new $assertion()]]></code>
     </MixedMethodCall>
     <MixedOperand>
-      <code>$assertion</code>
+      <code><![CDATA[$assertion]]></code>
     </MixedOperand>
-  </file>
-  <file src="src/Assertion/AssertionManager.php">
-    <MissingReturnType>
-      <code>validatePlugin</code>
-    </MissingReturnType>
-    <NonInvariantDocblockPropertyType>
-      <code>$instanceOf</code>
-    </NonInvariantDocblockPropertyType>
-    <PossiblyUnusedMethod>
-      <code>validatePlugin</code>
-    </PossiblyUnusedMethod>
   </file>
   <file src="src/Assertion/ExpressionAssertion.php">
     <InvalidNullableReturnType>
-      <code>bool</code>
+      <code><![CDATA[bool]]></code>
     </InvalidNullableReturnType>
     <MissingReturnType>
-      <code>validateOperand</code>
-      <code>validateOperator</code>
+      <code><![CDATA[validateOperand]]></code>
+      <code><![CDATA[validateOperator]]></code>
     </MissingReturnType>
     <MixedArgument>
       <code><![CDATA[$expression['operator']]]></code>
-      <code>$left</code>
-      <code>$left</code>
-      <code>$right</code>
-      <code>$right</code>
-      <code>$right</code>
-      <code>$right</code>
+      <code><![CDATA[$left]]></code>
+      <code><![CDATA[$left]]></code>
+      <code><![CDATA[$right]]></code>
+      <code><![CDATA[$right]]></code>
+      <code><![CDATA[$right]]></code>
+      <code><![CDATA[$right]]></code>
     </MixedArgument>
     <MixedAssignment>
-      <code>$left</code>
-      <code>$right</code>
+      <code><![CDATA[$left]]></code>
+      <code><![CDATA[$right]]></code>
     </MixedAssignment>
     <NullableReturnStatement>
       <code><![CDATA[static::evaluateExpression($left, $this->operator, $right)]]></code>
@@ -251,12 +240,12 @@
   </file>
   <file src="src/Resource/GenericResource.php">
     <RedundantCastGivenDocblockType>
-      <code>(string) $resourceId</code>
+      <code><![CDATA[(string) $resourceId]]></code>
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Role/GenericRole.php">
     <RedundantCastGivenDocblockType>
-      <code>(string) $roleId</code>
+      <code><![CDATA[(string) $roleId]]></code>
     </RedundantCastGivenDocblockType>
   </file>
   <file src="src/Role/Registry.php">
@@ -264,9 +253,9 @@
       <code><![CDATA[$this->roles]]></code>
     </InvalidPropertyAssignmentValue>
     <MixedArgument>
-      <code>$parentId</code>
-      <code>$roleParentId</code>
-      <code>$roleParentId</code>
+      <code><![CDATA[$parentId]]></code>
+      <code><![CDATA[$roleParentId]]></code>
+      <code><![CDATA[$roleParentId]]></code>
     </MixedArgument>
     <MixedArrayAccess>
       <code><![CDATA[$this->roles[$childId]['parents'][$roleId]]]></code>
@@ -276,7 +265,7 @@
       <code><![CDATA[$this->roles[$roleParentId]['children'][$roleId]]]></code>
     </MixedArrayAssignment>
     <MixedArrayOffset>
-      <code>$roleParents[$roleParentId]</code>
+      <code><![CDATA[$roleParents[$roleParentId]]]></code>
       <code><![CDATA[$this->roles[$childId]]]></code>
       <code><![CDATA[$this->roles[$parentId]]]></code>
       <code><![CDATA[$this->roles[$roleParentId]]]></code>
@@ -286,18 +275,18 @@
       <code><![CDATA[$this->roles[$roleParentId]]]></code>
     </MixedArrayTypeCoercion>
     <MixedAssignment>
-      <code>$child</code>
-      <code>$childId</code>
-      <code>$parent</code>
-      <code>$parent</code>
-      <code>$parent</code>
-      <code>$parentId</code>
-      <code>$parentId</code>
-      <code>$roleParentId</code>
+      <code><![CDATA[$child]]></code>
+      <code><![CDATA[$childId]]></code>
+      <code><![CDATA[$parent]]></code>
+      <code><![CDATA[$parent]]></code>
+      <code><![CDATA[$parent]]></code>
+      <code><![CDATA[$parentId]]></code>
+      <code><![CDATA[$parentId]]></code>
+      <code><![CDATA[$roleParentId]]></code>
     </MixedAssignment>
     <MixedInferredReturnType>
-      <code>RoleInterface</code>
-      <code>array</code>
+      <code><![CDATA[RoleInterface]]></code>
+      <code><![CDATA[array]]></code>
     </MixedInferredReturnType>
     <MixedPropertyTypeCoercion>
       <code><![CDATA[$this->roles]]></code>
@@ -307,11 +296,11 @@
       <code><![CDATA[$this->roles[$roleId]['parents']]]></code>
     </MixedReturnStatement>
     <PossiblyUndefinedVariable>
-      <code>$roleParentId</code>
+      <code><![CDATA[$roleParentId]]></code>
     </PossiblyUndefinedVariable>
     <RedundantCastGivenDocblockType>
-      <code>(string) $role</code>
-      <code>(string) $role</code>
+      <code><![CDATA[(string) $role]]></code>
+      <code><![CDATA[(string) $role]]></code>
     </RedundantCastGivenDocblockType>
     <UndefinedInterfaceMethod>
       <code><![CDATA[$this->roles[$childId]]]></code>
@@ -326,28 +315,28 @@
       <code><![CDATA[$this->roles[$roleParentId]]]></code>
     </UndefinedInterfaceMethod>
     <UnusedForeachValue>
-      <code>$child</code>
-      <code>$parent</code>
-      <code>$parent</code>
+      <code><![CDATA[$child]]></code>
+      <code><![CDATA[$parent]]></code>
+      <code><![CDATA[$parent]]></code>
     </UnusedForeachValue>
   </file>
   <file src="test/AclTest.php">
     <InvalidArgument>
-      <code>new stdClass()</code>
-      <code>new stdClass()</code>
+      <code><![CDATA[new stdClass()]]></code>
+      <code><![CDATA[new stdClass()]]></code>
     </InvalidArgument>
     <MissingReturnType>
-      <code>testAclResourcePermissionsAreInheritedWithMultilevelResourcesAndDenyPolicy</code>
-      <code>testAllowNullPermissionAfterResourcesExistShouldAllowAllPermissionsForRole</code>
-      <code>testRemoveDenyWithNullResourceAppliesToAllResources</code>
-      <code>testSetRuleWorksWithResourceInterface</code>
+      <code><![CDATA[testAclResourcePermissionsAreInheritedWithMultilevelResourcesAndDenyPolicy]]></code>
+      <code><![CDATA[testAllowNullPermissionAfterResourcesExistShouldAllowAllPermissionsForRole]]></code>
+      <code><![CDATA[testRemoveDenyWithNullResourceAppliesToAllResources]]></code>
+      <code><![CDATA[testSetRuleWorksWithResourceInterface]]></code>
     </MissingReturnType>
     <MixedAssignment>
-      <code>$roleParent</code>
-      <code>$roleParent</code>
+      <code><![CDATA[$roleParent]]></code>
+      <code><![CDATA[$roleParent]]></code>
     </MixedAssignment>
     <MixedMethodCall>
-      <code>getRoleId</code>
+      <code><![CDATA[getRoleId]]></code>
     </MixedMethodCall>
     <TooManyArguments>
       <code><![CDATA[new Resource\GenericResource('profiles', 'gallery')]]></code>
@@ -357,84 +346,84 @@
       <code><![CDATA[$assertion->assertReturnValue]]></code>
     </UndefinedClass>
     <UndefinedDocblockClass>
-      <code>$assertion</code>
-      <code>$assertion</code>
+      <code><![CDATA[$assertion]]></code>
+      <code><![CDATA[$assertion]]></code>
       <code><![CDATA[$assertion->lastAssertResource]]></code>
       <code><![CDATA[$assertion->lastAssertRole]]></code>
       <code><![CDATA[$assertion->lastAssertRole]]></code>
     </UndefinedDocblockClass>
     <UnusedForeachValue>
-      <code>$roleParent</code>
-      <code>$roleParent</code>
+      <code><![CDATA[$roleParent]]></code>
+      <code><![CDATA[$roleParent]]></code>
     </UnusedForeachValue>
   </file>
   <file src="test/Assertion/AssertionAggregateTest.php">
     <MissingReturnType>
-      <code>testClearAssertions</code>
+      <code><![CDATA[testClearAssertions]]></code>
     </MissingReturnType>
   </file>
   <file src="test/Assertion/CallbackAssertionTest.php">
     <MissingClosureParamType>
-      <code>$aclArg</code>
-      <code>$aclArg</code>
-      <code>$privilegeArg</code>
-      <code>$privilegeArg</code>
-      <code>$resourceArg</code>
-      <code>$resourceArg</code>
-      <code>$roleArg</code>
-      <code>$roleArg</code>
-      <code>$value</code>
+      <code><![CDATA[$aclArg]]></code>
+      <code><![CDATA[$aclArg]]></code>
+      <code><![CDATA[$privilegeArg]]></code>
+      <code><![CDATA[$privilegeArg]]></code>
+      <code><![CDATA[$resourceArg]]></code>
+      <code><![CDATA[$resourceArg]]></code>
+      <code><![CDATA[$roleArg]]></code>
+      <code><![CDATA[$roleArg]]></code>
+      <code><![CDATA[$value]]></code>
     </MissingClosureParamType>
     <MissingClosureReturnType>
       <code><![CDATA[static fn($aclArg, $roleArg, $resourceArg, $privilegeArg) => $value]]></code>
       <code><![CDATA[static fn($value) => static fn($aclArg, $roleArg, $resourceArg, $privilegeArg) => $value]]></code>
     </MissingClosureReturnType>
     <UnusedClosureParam>
-      <code>$aclArg</code>
-      <code>$privilegeArg</code>
-      <code>$resourceArg</code>
-      <code>$roleArg</code>
+      <code><![CDATA[$aclArg]]></code>
+      <code><![CDATA[$privilegeArg]]></code>
+      <code><![CDATA[$resourceArg]]></code>
+      <code><![CDATA[$roleArg]]></code>
     </UnusedClosureParam>
   </file>
   <file src="test/Assertion/ExpressionAssertionTest.php">
     <MissingReturnType>
-      <code>testExpressionsEvaluation</code>
+      <code><![CDATA[testExpressionsEvaluation]]></code>
     </MissingReturnType>
     <PossiblyUnusedMethod>
-      <code>getExpressions</code>
+      <code><![CDATA[getExpressions]]></code>
     </PossiblyUnusedMethod>
   </file>
   <file src="test/TestAsset/ExpressionUseCase/BlogPost.php">
     <PossiblyUnusedMethod>
-      <code>getAuthorName</code>
-      <code>getShortDescription</code>
+      <code><![CDATA[getAuthorName]]></code>
+      <code><![CDATA[getShortDescription]]></code>
     </PossiblyUnusedMethod>
     <PossiblyUnusedProperty>
-      <code>$content</code>
-      <code>$title</code>
+      <code><![CDATA[$content]]></code>
+      <code><![CDATA[$title]]></code>
     </PossiblyUnusedProperty>
   </file>
   <file src="test/TestAsset/ExpressionUseCase/User.php">
     <PossiblyUnusedMethod>
-      <code>isAdult</code>
+      <code><![CDATA[isAdult]]></code>
     </PossiblyUnusedMethod>
   </file>
   <file src="test/TestAsset/ExtendedAclLaminas2234.php">
     <PossiblyUnusedReturnValue>
-      <code>bool|void</code>
-      <code>bool|void</code>
-      <code>bool|void</code>
+      <code><![CDATA[bool|void]]></code>
+      <code><![CDATA[bool|void]]></code>
+      <code><![CDATA[bool|void]]></code>
     </PossiblyUnusedReturnValue>
   </file>
   <file src="test/TestAsset/StandardUseCase/UserIsBlogPostOwnerAssertion.php">
     <ParamNameMismatch>
-      <code>$blogPost</code>
-      <code>$user</code>
+      <code><![CDATA[$blogPost]]></code>
+      <code><![CDATA[$user]]></code>
     </ParamNameMismatch>
     <PossiblyUnusedProperty>
-      <code>$lastAssertPrivilege</code>
-      <code>$lastAssertResource</code>
-      <code>$lastAssertRole</code>
+      <code><![CDATA[$lastAssertPrivilege]]></code>
+      <code><![CDATA[$lastAssertResource]]></code>
+      <code><![CDATA[$lastAssertRole]]></code>
     </PossiblyUnusedProperty>
   </file>
 </files>

--- a/src/Assertion/AssertionManager.php
+++ b/src/Assertion/AssertionManager.php
@@ -4,30 +4,28 @@ declare(strict_types=1);
 
 namespace Laminas\Permissions\Acl\Assertion;
 
-use Laminas\Permissions\Acl\Exception\InvalidArgumentException;
-use Laminas\ServiceManager\AbstractPluginManager;
+use Laminas\ServiceManager\AbstractSingleInstancePluginManager;
 use Laminas\ServiceManager\Exception\InvalidServiceException;
 
 use function gettype;
 use function is_object;
 use function sprintf;
 
-/** @extends AbstractPluginManager<AssertionInterface> */
-class AssertionManager extends AbstractPluginManager
+/** @extends AbstractSingleInstancePluginManager<AssertionInterface> */
+class AssertionManager extends AbstractSingleInstancePluginManager
 {
     /** @var class-string<AssertionInterface> */
-    protected $instanceOf = AssertionInterface::class;
+    protected string $instanceOf = AssertionInterface::class;
 
     /**
      * Validate the plugin is of the expected type (v3).
      *
      * Validates against `$instanceOf`.
      *
-     * @param mixed $instance
      * @throws InvalidServiceException
      * @psalm-assert AssertionInterface $instance
      */
-    public function validate($instance)
+    public function validate(mixed $instance): void
     {
         if (! $instance instanceof $this->instanceOf) {
             throw new InvalidServiceException(sprintf(
@@ -36,25 +34,6 @@ class AssertionManager extends AbstractPluginManager
                 $this->instanceOf,
                 is_object($instance) ? $instance::class : gettype($instance)
             ));
-        }
-    }
-
-    /**
-     * Validate the plugin is of the expected type (v2).
-     *
-     * Proxies to `validate()`.
-     *
-     * @deprecated Please use {@see AssertionManager::validate()} instead.
-     *
-     * @throws InvalidArgumentException
-     * @psalm-assert AssertionInterface $instance
-     */
-    public function validatePlugin(mixed $instance)
-    {
-        try {
-            $this->validate($instance);
-        } catch (InvalidServiceException $e) {
-            throw new InvalidArgumentException($e->getMessage(), $e->getCode(), $e);
         }
     }
 }

--- a/test/Assertion/AssertionManagerCompatibilityTest.php
+++ b/test/Assertion/AssertionManagerCompatibilityTest.php
@@ -6,25 +6,18 @@ namespace LaminasTest\Permissions\Acl\Assertion;
 
 use Laminas\Permissions\Acl\Assertion\AssertionInterface;
 use Laminas\Permissions\Acl\Assertion\AssertionManager;
-use Laminas\Permissions\Acl\Exception\InvalidArgumentException;
+use Laminas\ServiceManager\AbstractSingleInstancePluginManager;
 use Laminas\ServiceManager\ServiceManager;
 use Laminas\ServiceManager\Test\CommonPluginManagerTrait;
 use PHPUnit\Framework\TestCase;
-use Throwable;
 
 class AssertionManagerCompatibilityTest extends TestCase
 {
     use CommonPluginManagerTrait;
 
-    protected static function getPluginManager(): AssertionManager
+    protected static function getPluginManager(array $config = []): AbstractSingleInstancePluginManager
     {
         return new AssertionManager(new ServiceManager());
-    }
-
-    /** @return class-string<Throwable> */
-    protected function getV2InvalidPluginException(): string
-    {
-        return InvalidArgumentException::class;
     }
 
     /** @return class-string */


### PR DESCRIPTION
This patch is a BC break because AssertionManager inheritance has changed to `AbstractSingleInstancePluginManager`

Closes #50 